### PR TITLE
feat: add :ObsidianQuickKensaku

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,18 @@ If you want to customize the way, call `setup` or write them in `opts` (for
 }
 ```
 
-## Command
+## Commands
 
 ### `:ObsidianKensaku`
 
-Open the picker like `:ObsidianSearch`. You can search with Romaji and do the
-same things as in `:ObsidianSearch`.
+Open the picker like `:ObsidianSearch`. You can search note **contents** with
+Romaji and do the same things as in `:ObsidianSearch`.
+
+### `:ObsidianQuickKensaku`
+
+Open the picker like `:ObsidianQuickSwitch`. You can search notes by **file
+name** with Romaji. This is the kensaku-powered equivalent of
+`:ObsidianQuickSwitch`.
 
 ## Options
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -3,12 +3,12 @@
 ==============================================================================
 目次						     *obsidian-kensaku-contents*
 
-|obsidian-kensaku-introduction|	はじめに
-|obsidian-kensaku-requirements|	必要なもの
-|obsidian-kensaku-install|	インストール
-|obsidian-kensaku-commands|	コマンド
-|obsidian-kensaku-options|	オプション
-|obsidian-kensaku-license|	ライセンス
+はじめに					 |obsidian-kensaku-introduction|
+必要なもの					 |obsidian-kensaku-requirements|
+インストール					      |obsidian-kensaku-install|
+コマンド					     |obsidian-kensaku-commands|
+オプション					      |obsidian-kensaku-options|
+ライセンス					      |obsidian-kensaku-license|
 
 ==============================================================================
 はじめに					 *obsidian-kensaku-introduction*

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -1,17 +1,17 @@
 *obsidian-kensaku.txt*	ローマ字で vault を検索
 
 ==============================================================================
-目次					     *obsidian-kensaku-contents*
+目次						     *obsidian-kensaku-contents*
 
-    1. はじめに ............................ |obsidian-kensaku-introduction|
-    2. 必要なもの .......................... |obsidian-kensaku-requirements|
-    3. インストール ............................ |obsidian-kensaku-install|
-    4. コマンド ............................ |obsidian-kensaku-commands|
-    5. オプション .......................... |obsidian-kensaku-options|
-    6. ライセンス .......................... |obsidian-kensaku-license|
+    1. はじめに ................................ |obsidian-kensaku-introduction|
+    2. 必要なもの .............................. |obsidian-kensaku-requirements|
+    3. インストール ................................. |obsidian-kensaku-install|
+    4. コマンド .................................... |obsidian-kensaku-commands|
+    5. オプション ................................... |obsidian-kensaku-options|
+    6. ライセンス ................................... |obsidian-kensaku-license|
 
 ==============================================================================
-はじめに				 *obsidian-kensaku-introduction*
+はじめに					 *obsidian-kensaku-introduction*
 
 obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加する
 プラグインです。以下の二つのコマンドを提供します。
@@ -24,7 +24,7 @@ obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加�
 ドを切り替えずに日本語テキストを検索できます。
 
 ==============================================================================
-必要なもの				 *obsidian-kensaku-requirements*
+必要なもの					 *obsidian-kensaku-requirements*
 
 - Neovim >= 0.10.0
 - epwalsh/obsidian.nvim
@@ -40,7 +40,7 @@ obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加�
     https://github.com/fdschmidt93/telescope-egrepify.nvim
 
 ==============================================================================
-インストール				      *obsidian-kensaku-install*
+インストール					      *obsidian-kensaku-install*
 
 kensaku.vim を使う場合の lazy.nvim 設定例 (デフォルト): >lua
     {
@@ -85,23 +85,23 @@ cmigemo を使う場合: >lua
 <
 
 ==============================================================================
-コマンド				     *obsidian-kensaku-commands*
+コマンド					     *obsidian-kensaku-commands*
 
-:ObsidianKensaku [query]			     *:ObsidianKensaku*
+:ObsidianKensaku [query]				      *:ObsidianKensaku*
 
 	ローマ字で vault のノート内容を検索します。
 	|:ObsidianSearch| と同様に動作しますが、ローマ字入力を正規
 	表現に変換して日本語テキストをマッチングします。[query] を
 	指定すると初期検索クエリとして使用されます。
 
-:ObsidianQuickKensaku				*:ObsidianQuickKensaku*
+:ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
 
 	ローマ字でファイル名からノートを検索します。
 	|:ObsidianQuickSwitch| と同様に動作しますが、ローマ字入力を
 	正規表現に変換して日本語テキストをマッチングします。
 
 ==============================================================================
-オプション				      *obsidian-kensaku-options*
+オプション					      *obsidian-kensaku-options*
 
 setup 関数または lazy.nvim の `opts` でオプションを設定できます: >lua
     require("obsidian-kensaku").setup {
@@ -109,7 +109,7 @@ setup 関数または lazy.nvim の `opts` でオプションを設定できま�
       picker = "egrepify",
     }
 <
-					 *obsidian-kensaku-query_filter*
+						 *obsidian-kensaku-query_filter*
 query_filter ~
 	型: `"kensaku"` | `"cmigemo"` | `fun(query: string): string`
 	デフォルト: `"kensaku"`
@@ -127,7 +127,7 @@ query_filter ~
 	      end,
 	    }
 <
-				      *obsidian-kensaku-cmigemo_executable*
+					   *obsidian-kensaku-cmigemo_executable*
 cmigemo_executable ~
 	型: `string`
 	デフォルト: `"cmigemo"`
@@ -136,7 +136,7 @@ cmigemo_executable ~
 	|obsidian-kensaku-query_filter| が `"cmigemo"` の場合のみ
 	使用されます。
 
-					*obsidian-kensaku-migemo_dict_path*
+					     *obsidian-kensaku-migemo_dict_path*
 migemo_dict_path ~
 	型: `string`
 	デフォルト: (自動検出)
@@ -146,7 +146,7 @@ migemo_dict_path ~
 	使用されます。指定しない場合、プラグインが自動的に検索しま
 	す。
 
-					       *obsidian-kensaku-picker*
+						       *obsidian-kensaku-picker*
 picker ~
 	型: `"default"` | `"egrepify"`
 	デフォルト: `"default"`
@@ -156,7 +156,7 @@ picker ~
 	善されます。
 
 ==============================================================================
-ライセンス				      *obsidian-kensaku-license*
+ライセンス					      *obsidian-kensaku-license*
 
 MIT ライセンス。
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -3,12 +3,12 @@
 ==============================================================================
 目次						     *obsidian-kensaku-contents*
 
-    1. はじめに ................................ |obsidian-kensaku-introduction|
-    2. 必要なもの .............................. |obsidian-kensaku-requirements|
-    3. インストール ................................. |obsidian-kensaku-install|
-    4. コマンド .................................... |obsidian-kensaku-commands|
-    5. オプション ................................... |obsidian-kensaku-options|
-    6. ライセンス ................................... |obsidian-kensaku-license|
+|obsidian-kensaku-introduction|	はじめに
+|obsidian-kensaku-requirements|	必要なもの
+|obsidian-kensaku-install|	インストール
+|obsidian-kensaku-commands|	コマンド
+|obsidian-kensaku-options|	オプション
+|obsidian-kensaku-license|	ライセンス
 
 ==============================================================================
 はじめに					 *obsidian-kensaku-introduction*

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -1,0 +1,164 @@
+*obsidian-kensaku.txt*	ローマ字で vault を検索
+
+==============================================================================
+目次					     *obsidian-kensaku-contents*
+
+    1. はじめに ............................ |obsidian-kensaku-introduction|
+    2. 必要なもの .......................... |obsidian-kensaku-requirements|
+    3. インストール ............................ |obsidian-kensaku-install|
+    4. コマンド ............................ |obsidian-kensaku-commands|
+    5. オプション .......................... |obsidian-kensaku-options|
+    6. ライセンス .......................... |obsidian-kensaku-license|
+
+==============================================================================
+はじめに				 *obsidian-kensaku-introduction*
+
+obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加する
+プラグインです。以下の二つのコマンドを提供します。
+
+- |:ObsidianKensaku| ノートの内容を検索 (|:ObsidianSearch| 相当)
+- |:ObsidianQuickKensaku| ファイル名でノートを検索
+  (|:ObsidianQuickSwitch| 相当)
+
+ローマ字入力を kensaku.vim や cmigemo で正規表現に変換し、入力メソッ
+ドを切り替えずに日本語テキストを検索できます。
+
+==============================================================================
+必要なもの				 *obsidian-kensaku-requirements*
+
+- Neovim >= 0.10.0
+- epwalsh/obsidian.nvim
+    https://github.com/epwalsh/obsidian.nvim
+- nvim-telescope/telescope.nvim
+    https://github.com/nvim-telescope/telescope.nvim
+- 以下のローマ字変換器のいずれか:
+  - lambdalisue/kensaku.vim (vim-denops/denops.vim が必要)
+      https://github.com/lambdalisue/kensaku.vim
+  - `cmigemo` 実行ファイル
+  - 独自の変換関数
+- fdschmidt93/telescope-egrepify.nvim (任意、推奨)
+    https://github.com/fdschmidt93/telescope-egrepify.nvim
+
+==============================================================================
+インストール				      *obsidian-kensaku-install*
+
+kensaku.vim を使う場合の lazy.nvim 設定例 (デフォルト): >lua
+    {
+      "epwalsh/obsidian.nvim",
+      dependencies = {
+        "nvim-lua/plenary.nvim",
+        "delphinus/obsidian-kensaku.nvim",
+      },
+      opts = {
+        callbacks = {
+          post_setup = function(client)
+            require "obsidian-kensaku"(client)
+          end,
+        },
+      },
+    }
+<
+重要: `opts.callbacks.post_setup` 内で呼び出す必要があります。
+
+cmigemo を使う場合: >lua
+    {
+      "epwalsh/obsidian.nvim",
+      dependencies = {
+        "nvim-lua/plenary.nvim",
+        {
+          "delphinus/obsidian-kensaku.nvim",
+          opts = {
+            query_filter = "cmigemo",
+            cmigemo_executable = "/path/to/cmigemo",
+            migemo_dict_path = "/path/to/migemo-dict",
+          },
+        },
+      },
+      opts = {
+        callbacks = {
+          post_setup = function(client)
+            require "obsidian-kensaku"(client)
+          end,
+        },
+      },
+    }
+<
+
+==============================================================================
+コマンド				     *obsidian-kensaku-commands*
+
+:ObsidianKensaku [query]			     *:ObsidianKensaku*
+
+	ローマ字で vault のノート内容を検索します。
+	|:ObsidianSearch| と同様に動作しますが、ローマ字入力を正規
+	表現に変換して日本語テキストをマッチングします。[query] を
+	指定すると初期検索クエリとして使用されます。
+
+:ObsidianQuickKensaku				*:ObsidianQuickKensaku*
+
+	ローマ字でファイル名からノートを検索します。
+	|:ObsidianQuickSwitch| と同様に動作しますが、ローマ字入力を
+	正規表現に変換して日本語テキストをマッチングします。
+
+==============================================================================
+オプション				      *obsidian-kensaku-options*
+
+setup 関数または lazy.nvim の `opts` でオプションを設定できます: >lua
+    require("obsidian-kensaku").setup {
+      query_filter = "kensaku",
+      picker = "egrepify",
+    }
+<
+					 *obsidian-kensaku-query_filter*
+query_filter ~
+	型: `"kensaku"` | `"cmigemo"` | `fun(query: string): string`
+	デフォルト: `"kensaku"`
+
+	ローマ字を正規表現に変換する方法を指定します。
+
+	`"kensaku"`    lambdalisue/kensaku.vim を使用。
+	`"cmigemo"`    cmigemo 実行ファイルを使用。
+	関数         クエリ文字列を受け取り正規表現を返す独自関数。
+
+	独自関数の使用例: >lua
+	    {
+	      query_filter = function(query)
+	        return some_way_to_create_regex(query)
+	      end,
+	    }
+<
+				      *obsidian-kensaku-cmigemo_executable*
+cmigemo_executable ~
+	型: `string`
+	デフォルト: `"cmigemo"`
+
+	cmigemo 実行ファイルのパス。
+	|obsidian-kensaku-query_filter| が `"cmigemo"` の場合のみ
+	使用されます。
+
+					*obsidian-kensaku-migemo_dict_path*
+migemo_dict_path ~
+	型: `string`
+	デフォルト: (自動検出)
+
+	migemo 辞書ファイルのパス。
+	|obsidian-kensaku-query_filter| が `"cmigemo"` の場合のみ
+	使用されます。指定しない場合、プラグインが自動的に検索しま
+	す。
+
+					       *obsidian-kensaku-picker*
+picker ~
+	型: `"default"` | `"egrepify"`
+	デフォルト: `"default"`
+
+	使用する telescope ピッカー。 `"egrepify"` に設定すると
+	telescope-egrepify.nvim を使用し、正規表現のハイライトが改
+	善されます。
+
+==============================================================================
+ライセンス				      *obsidian-kensaku-license*
+
+MIT ライセンス。
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -3,12 +3,12 @@
 ==============================================================================
 CONTENTS					     *obsidian-kensaku-contents*
 
-    1. Introduction ............................ |obsidian-kensaku-introduction|
-    2. Requirements ............................ |obsidian-kensaku-requirements|
-    3. Installation ................................. |obsidian-kensaku-install|
-    4. Commands .................................... |obsidian-kensaku-commands|
-    5. Options ...................................... |obsidian-kensaku-options|
-    6. License ...................................... |obsidian-kensaku-license|
+|obsidian-kensaku-introduction|	Introduction
+|obsidian-kensaku-requirements|	Requirements
+|obsidian-kensaku-install|	Installation
+|obsidian-kensaku-commands|	Commands
+|obsidian-kensaku-options|	Options
+|obsidian-kensaku-license|	License
 
 ==============================================================================
 INTRODUCTION					 *obsidian-kensaku-introduction*

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -3,12 +3,12 @@
 ==============================================================================
 CONTENTS					     *obsidian-kensaku-contents*
 
-|obsidian-kensaku-introduction|	Introduction
-|obsidian-kensaku-requirements|	Requirements
-|obsidian-kensaku-install|	Installation
-|obsidian-kensaku-commands|	Commands
-|obsidian-kensaku-options|	Options
-|obsidian-kensaku-license|	License
+Introduction					 |obsidian-kensaku-introduction|
+Requirements					 |obsidian-kensaku-requirements|
+Installation					      |obsidian-kensaku-install|
+Commands					     |obsidian-kensaku-commands|
+Options						      |obsidian-kensaku-options|
+License						      |obsidian-kensaku-license|
 
 ==============================================================================
 INTRODUCTION					 *obsidian-kensaku-introduction*

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -1,0 +1,163 @@
+*obsidian-kensaku.txt*	Search vault with Romaji
+
+==============================================================================
+CONTENTS				     *obsidian-kensaku-contents*
+
+    1. Introduction ............................ |obsidian-kensaku-introduction|
+    2. Requirements ............................ |obsidian-kensaku-requirements|
+    3. Installation ................................ |obsidian-kensaku-install|
+    4. Commands .................................... |obsidian-kensaku-commands|
+    5. Options ...................................... |obsidian-kensaku-options|
+    6. License ...................................... |obsidian-kensaku-license|
+
+==============================================================================
+INTRODUCTION				 *obsidian-kensaku-introduction*
+
+obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|.
+It provides two commands:
+
+- |:ObsidianKensaku| searches note contents (like |:ObsidianSearch|)
+- |:ObsidianQuickKensaku| searches notes by file name
+  (like |:ObsidianQuickSwitch|)
+
+Romaji input is converted to regex using kensaku.vim or cmigemo, enabling
+you to search Japanese text without switching input methods.
+
+==============================================================================
+REQUIREMENTS				 *obsidian-kensaku-requirements*
+
+- Neovim >= 0.10.0
+- epwalsh/obsidian.nvim
+    https://github.com/epwalsh/obsidian.nvim
+- nvim-telescope/telescope.nvim
+    https://github.com/nvim-telescope/telescope.nvim
+- One of the following Romaji converters:
+  - lambdalisue/kensaku.vim (requires vim-denops/denops.vim)
+      https://github.com/lambdalisue/kensaku.vim
+  - `cmigemo` executable
+  - A custom converter function
+- fdschmidt93/telescope-egrepify.nvim (optional, recommended)
+    https://github.com/fdschmidt93/telescope-egrepify.nvim
+
+==============================================================================
+INSTALLATION				      *obsidian-kensaku-install*
+
+Example configuration with lazy.nvim using kensaku.vim (the default): >lua
+    {
+      "epwalsh/obsidian.nvim",
+      dependencies = {
+        "nvim-lua/plenary.nvim",
+        "delphinus/obsidian-kensaku.nvim",
+      },
+      opts = {
+        callbacks = {
+          post_setup = function(client)
+            require "obsidian-kensaku"(client)
+          end,
+        },
+      },
+    }
+<
+IMPORTANT: You must call this plugin in `opts.callbacks.post_setup`.
+
+If you want to use cmigemo instead of kensaku.vim: >lua
+    {
+      "epwalsh/obsidian.nvim",
+      dependencies = {
+        "nvim-lua/plenary.nvim",
+        {
+          "delphinus/obsidian-kensaku.nvim",
+          opts = {
+            query_filter = "cmigemo",
+            cmigemo_executable = "/path/to/cmigemo",
+            migemo_dict_path = "/path/to/migemo-dict",
+          },
+        },
+      },
+      opts = {
+        callbacks = {
+          post_setup = function(client)
+            require "obsidian-kensaku"(client)
+          end,
+        },
+      },
+    }
+<
+
+==============================================================================
+COMMANDS				     *obsidian-kensaku-commands*
+
+:ObsidianKensaku [query]			     *:ObsidianKensaku*
+
+	Search vault note contents with Romaji. Works like
+	|:ObsidianSearch| but converts Romaji input to regex for
+	Japanese text matching. If [query] is given, it is used as the
+	initial search query.
+
+:ObsidianQuickKensaku				*:ObsidianQuickKensaku*
+
+	Search vault notes by file name with Romaji. Works like
+	|:ObsidianQuickSwitch| but converts Romaji input to regex for
+	Japanese text matching.
+
+==============================================================================
+OPTIONS					      *obsidian-kensaku-options*
+
+Options can be passed to the setup function or as `opts` in lazy.nvim: >lua
+    require("obsidian-kensaku").setup {
+      query_filter = "kensaku",
+      picker = "egrepify",
+    }
+<
+					 *obsidian-kensaku-query_filter*
+query_filter ~
+	Type: `"kensaku"` | `"cmigemo"` | `fun(query: string): string`
+	Default: `"kensaku"`
+
+	The method to convert Romaji into regex.
+
+	`"kensaku"`    Use lambdalisue/kensaku.vim.
+	`"cmigemo"`    Use the cmigemo executable.
+	function     A custom function that takes a query string and
+	             returns a regex string.
+
+	Example with a custom function: >lua
+	    {
+	      query_filter = function(query)
+	        return some_way_to_create_regex(query)
+	      end,
+	    }
+<
+				      *obsidian-kensaku-cmigemo_executable*
+cmigemo_executable ~
+	Type: `string`
+	Default: `"cmigemo"`
+
+	Path to the cmigemo executable. Only used when
+	|obsidian-kensaku-query_filter| is `"cmigemo"`.
+
+					*obsidian-kensaku-migemo_dict_path*
+migemo_dict_path ~
+	Type: `string`
+	Default: (auto-detected)
+
+	Path to the migemo dictionary file. Only used when
+	|obsidian-kensaku-query_filter| is `"cmigemo"`. If not
+	specified, the plugin will search for it automatically.
+
+					       *obsidian-kensaku-picker*
+picker ~
+	Type: `"default"` | `"egrepify"`
+	Default: `"default"`
+
+	The telescope picker to use. Set to `"egrepify"` to use
+	telescope-egrepify.nvim, which provides better regex
+	highlighting.
+
+==============================================================================
+LICENSE					      *obsidian-kensaku-license*
+
+MIT license.
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -1,17 +1,17 @@
 *obsidian-kensaku.txt*	Search vault with Romaji
 
 ==============================================================================
-CONTENTS				     *obsidian-kensaku-contents*
+CONTENTS					     *obsidian-kensaku-contents*
 
     1. Introduction ............................ |obsidian-kensaku-introduction|
     2. Requirements ............................ |obsidian-kensaku-requirements|
-    3. Installation ................................ |obsidian-kensaku-install|
+    3. Installation ................................. |obsidian-kensaku-install|
     4. Commands .................................... |obsidian-kensaku-commands|
     5. Options ...................................... |obsidian-kensaku-options|
     6. License ...................................... |obsidian-kensaku-license|
 
 ==============================================================================
-INTRODUCTION				 *obsidian-kensaku-introduction*
+INTRODUCTION					 *obsidian-kensaku-introduction*
 
 obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|.
 It provides two commands:
@@ -24,7 +24,7 @@ Romaji input is converted to regex using kensaku.vim or cmigemo, enabling
 you to search Japanese text without switching input methods.
 
 ==============================================================================
-REQUIREMENTS				 *obsidian-kensaku-requirements*
+REQUIREMENTS					 *obsidian-kensaku-requirements*
 
 - Neovim >= 0.10.0
 - epwalsh/obsidian.nvim
@@ -40,7 +40,7 @@ REQUIREMENTS				 *obsidian-kensaku-requirements*
     https://github.com/fdschmidt93/telescope-egrepify.nvim
 
 ==============================================================================
-INSTALLATION				      *obsidian-kensaku-install*
+INSTALLATION					      *obsidian-kensaku-install*
 
 Example configuration with lazy.nvim using kensaku.vim (the default): >lua
     {
@@ -85,23 +85,23 @@ If you want to use cmigemo instead of kensaku.vim: >lua
 <
 
 ==============================================================================
-COMMANDS				     *obsidian-kensaku-commands*
+COMMANDS					     *obsidian-kensaku-commands*
 
-:ObsidianKensaku [query]			     *:ObsidianKensaku*
+:ObsidianKensaku [query]				      *:ObsidianKensaku*
 
 	Search vault note contents with Romaji. Works like
 	|:ObsidianSearch| but converts Romaji input to regex for
 	Japanese text matching. If [query] is given, it is used as the
 	initial search query.
 
-:ObsidianQuickKensaku				*:ObsidianQuickKensaku*
+:ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
 
 	Search vault notes by file name with Romaji. Works like
 	|:ObsidianQuickSwitch| but converts Romaji input to regex for
 	Japanese text matching.
 
 ==============================================================================
-OPTIONS					      *obsidian-kensaku-options*
+OPTIONS						      *obsidian-kensaku-options*
 
 Options can be passed to the setup function or as `opts` in lazy.nvim: >lua
     require("obsidian-kensaku").setup {
@@ -109,7 +109,7 @@ Options can be passed to the setup function or as `opts` in lazy.nvim: >lua
       picker = "egrepify",
     }
 <
-					 *obsidian-kensaku-query_filter*
+						 *obsidian-kensaku-query_filter*
 query_filter ~
 	Type: `"kensaku"` | `"cmigemo"` | `fun(query: string): string`
 	Default: `"kensaku"`
@@ -128,7 +128,7 @@ query_filter ~
 	      end,
 	    }
 <
-				      *obsidian-kensaku-cmigemo_executable*
+					   *obsidian-kensaku-cmigemo_executable*
 cmigemo_executable ~
 	Type: `string`
 	Default: `"cmigemo"`
@@ -136,7 +136,7 @@ cmigemo_executable ~
 	Path to the cmigemo executable. Only used when
 	|obsidian-kensaku-query_filter| is `"cmigemo"`.
 
-					*obsidian-kensaku-migemo_dict_path*
+					     *obsidian-kensaku-migemo_dict_path*
 migemo_dict_path ~
 	Type: `string`
 	Default: (auto-detected)
@@ -145,7 +145,7 @@ migemo_dict_path ~
 	|obsidian-kensaku-query_filter| is `"cmigemo"`. If not
 	specified, the plugin will search for it automatically.
 
-					       *obsidian-kensaku-picker*
+						       *obsidian-kensaku-picker*
 picker ~
 	Type: `"default"` | `"egrepify"`
 	Default: `"default"`
@@ -155,7 +155,7 @@ picker ~
 	highlighting.
 
 ==============================================================================
-LICENSE					      *obsidian-kensaku-license*
+LICENSE						      *obsidian-kensaku-license*
 
 MIT license.
 

--- a/lua/obsidian-kensaku.lua
+++ b/lua/obsidian-kensaku.lua
@@ -13,6 +13,10 @@ return setmetatable({ setup_called = false }, {
       local picker = require("obsidian-kensaku.picker").new(client)
       picker:grep_notes { query = data.args }
     end, { nargs = "?", desc = "Search vault with kensaku.vim" })
+    vim.api.nvim_create_user_command("ObsidianQuickKensaku", function(data)
+      local picker = require("obsidian-kensaku.picker").new(client)
+      picker:find_notes()
+    end, { nargs = "?", desc = "Search vault with kensaku.vim" })
   end,
   ---@param key string
   __index = function(self, key)

--- a/lua/obsidian-kensaku/picker.lua
+++ b/lua/obsidian-kensaku/picker.lua
@@ -127,6 +127,36 @@ local function attach_picker_mappings(map, opts)
   end
 end
 
+---@param opts obsidian.PickerFindOpts|? Options.
+KensakuPicker.find_files = function(self, opts)
+  opts = opts or {}
+
+  local prompt_title = self:_build_prompt {
+    prompt_title = opts.prompt_title,
+    query_mappings = opts.query_mappings,
+    selection_mappings = opts.selection_mappings,
+  }
+
+  telescope_builtin.find_files {
+    prompt_title = prompt_title,
+    cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
+    find_command = self:_build_find_cmd(),
+    sorter = require "obsidian-kensaku.regex_sorter",
+    on_input_filter_cb = function(prompt)
+      return { prompt = vim.fn["kensaku#query"](prompt, { rxop = vim.g["kensaku#rxop#vim"] }) }
+    end,
+    attach_mappings = function(_, map)
+      attach_picker_mappings(map, {
+        entry_key = "path",
+        callback = opts.callback,
+        query_mappings = opts.query_mappings,
+        selection_mappings = opts.selection_mappings,
+      })
+      return true
+    end,
+  }
+end
+
 ---@param opts obsidian.PickerGrepOpts|? Options.
 KensakuPicker.grep = function(self, opts)
   opts = opts or {}

--- a/lua/obsidian-kensaku/regex_sorter.lua
+++ b/lua/obsidian-kensaku/regex_sorter.lua
@@ -1,0 +1,31 @@
+local sorters = require "telescope.sorters"
+
+---@type table<string, vim.regex>
+local cache = {}
+
+return sorters.Sorter:new {
+  ---@param prompt string
+  ---@param line string
+  ---@param entry table
+  ---@return number
+  scoring_function = function(_, prompt, line, entry)
+    if #prompt == 0 then
+      return 1
+    end
+    if not cache[prompt] then
+      cache[prompt] = vim.regex(prompt)
+    end
+    return not not cache[prompt]:match_str(line) and 1 or -1
+  end,
+
+  ---@param prompt string
+  ---@param display string
+  highlighter = function(_, prompt, display)
+    if #prompt == 0 then
+      return {}
+    end
+
+    local start, finish = vim.regex(prompt):match_str(display)
+    return start and finish and { { start = start, finish = finish } } or {}
+  end,
+}


### PR DESCRIPTION
## Summary

- Add `:ObsidianQuickKensaku` command for searching vault notes by **file name** using Romaji
- Override `find_files` in `KensakuPicker` to use kensaku.vim for Romaji-to-regex conversion
- Add custom `regex_sorter` for Telescope that handles Vim-style regex patterns from kensaku.vim

## Background

`:ObsidianKensaku` searches note **contents** (grep). This PR adds a complementary command `:ObsidianQuickKensaku` that searches by **file name**, similar to the relationship between `:ObsidianSearch` and `:ObsidianQuickSwitch` in obsidian.nvim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)