### PR TITLE
feat: add previewer option for custom telescope previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ Use [fdschmidt93/telescope-egrepify.nvim][] instead of telescope's builtin.
 * type: `fun(): table`
 
 A function that returns a custom telescope previewer. When set, it is used
-for all picker commands.
+for all picker commands. For example, [delphinus/md-render.nvim][] can render
+Markdown in the preview window:
 
 ```lua
 {
@@ -203,6 +204,8 @@ for all picker commands.
   end,
 }
 ```
+
+[delphinus/md-render.nvim]: https://github.com/delphinus/md-render.nvim
 
 ## LICENSE
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,22 @@ Path for `migemo-dict`. This will be used only if `query_filter` is `"cmigemo"`.
 
 Use [fdschmidt93/telescope-egrepify.nvim][] instead of telescope's builtin.
 
+### `previewer`
+
+* default: `nil`
+* type: `fun(): table`
+
+A function that returns a custom telescope previewer. When set, it is used
+for all picker commands.
+
+```lua
+{
+  previewer = function()
+    return require("md-render.telescope").previewer()
+  end,
+}
+```
+
 ## LICENSE
 
 MIT license.

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -13,15 +13,15 @@
 ==============================================================================
 はじめに					 *obsidian-kensaku-introduction*
 
-obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加する
-プラグインです。以下の二つのコマンドを提供します。
+obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加するプラグイン
+です。以下の二つのコマンドを提供します。
 
 - |:ObsidianKensaku| ノートの内容を検索 (|:ObsidianSearch| 相当)
 - |:ObsidianQuickKensaku| ファイル名でノートを検索
   (|:ObsidianQuickSwitch| 相当)
 
-ローマ字入力を kensaku.vim や cmigemo で正規表現に変換し、入力メソッ
-ドを切り替えずに日本語テキストを検索できます。
+ローマ字入力を kensaku.vim や cmigemo で正規表現に変換し、入力メソッドを切り替
+えずに日本語テキストを検索できます。
 
 ==============================================================================
 必要なもの					 *obsidian-kensaku-requirements*
@@ -89,16 +89,15 @@ cmigemo を使う場合: >lua
 
 :ObsidianKensaku [query]				      *:ObsidianKensaku*
 
-	ローマ字で vault のノート内容を検索します。
-	|:ObsidianSearch| と同様に動作しますが、ローマ字入力を正規
-	表現に変換して日本語テキストをマッチングします。[query] を
-	指定すると初期検索クエリとして使用されます。
+	ローマ字で vault のノート内容を検索します。 |:ObsidianSearch| と同様に動
+	作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッチング
+	します。[query] を指定すると初期検索クエリとして使用されます。
 
 :ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
 
-	ローマ字でファイル名からノートを検索します。
-	|:ObsidianQuickSwitch| と同様に動作しますが、ローマ字入力を
-	正規表現に変換して日本語テキストをマッチングします。
+	ローマ字でファイル名からノートを検索します。 |:ObsidianQuickSwitch| と同
+	様に動作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッ
+	チングします。
 
 ==============================================================================
 オプション					      *obsidian-kensaku-options*
@@ -132,18 +131,16 @@ cmigemo_executable ~
 	型: `string`
 	デフォルト: `"cmigemo"`
 
-	cmigemo 実行ファイルのパス。
-	|obsidian-kensaku-query_filter| が `"cmigemo"` の場合のみ
-	使用されます。
+	cmigemo 実行ファイルのパス。 |obsidian-kensaku-query_filter| が
+	`"cmigemo"` の場合のみ使用されます。
 
 					     *obsidian-kensaku-migemo_dict_path*
 migemo_dict_path ~
 	型: `string`
 	デフォルト: (自動検出)
 
-	migemo 辞書ファイルのパス。
-	|obsidian-kensaku-query_filter| が `"cmigemo"` の場合のみ
-	使用されます。指定しない場合、プラグインが自動的に検索しま
+	migemo 辞書ファイルのパス。 |obsidian-kensaku-query_filter| が `"cmigemo"`
+	の場合のみ使用されます。指定しない場合、プラグインが自動的に検索しま
 	す。
 
 						       *obsidian-kensaku-picker*
@@ -152,17 +149,16 @@ picker ~
 	デフォルト: `"default"`
 
 	使用する telescope ピッカー。 `"egrepify"` に設定すると
-	telescope-egrepify.nvim を使用し、正規表現のハイライトが改
-	善されます。
+	telescope-egrepify.nvim を使用し、正規表現のハイライトが改善されます。
 
 						    *obsidian-kensaku-previewer*
 previewer ~
 	型: `fun(): table`
 	デフォルト: `nil`
 
-	カスタム telescope プレビューアを返す関数。設定すると、すべ
-	てのピッカーコマンドで使用されます。例えば md-render.nvim
-	を使うとプレビューで Markdown を描画できます。
+	カスタム telescope プレビューアを返す関数。設定すると、すべてのピッ
+	カーコマンドで使用されます。例えば md-render.nvim を使うとプレビューで
+	Markdown を描画できます。
 
 	  https://github.com/delphinus/md-render.nvim
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -161,9 +161,12 @@ previewer ~
 	デフォルト: `nil`
 
 	カスタム telescope プレビューアを返す関数。設定すると、すべ
-	てのピッカーコマンドで使用されます。
+	てのピッカーコマンドで使用されます。例えば md-render.nvim
+	を使うとプレビューで Markdown を描画できます。
 
-	md-render.nvim との連携例: >lua
+	  https://github.com/delphinus/md-render.nvim
+
+	使用例: >lua
 	    {
 	      previewer = function()
 	        return require("md-render.telescope").previewer()

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -155,6 +155,22 @@ picker ~
 	telescope-egrepify.nvim を使用し、正規表現のハイライトが改
 	善されます。
 
+						    *obsidian-kensaku-previewer*
+previewer ~
+	型: `fun(): table`
+	デフォルト: `nil`
+
+	カスタム telescope プレビューアを返す関数。設定すると、すべ
+	てのピッカーコマンドで使用されます。
+
+	md-render.nvim との連携例: >lua
+	    {
+	      previewer = function()
+	        return require("md-render.telescope").previewer()
+	      end,
+	    }
+<
+
 ==============================================================================
 ライセンス					      *obsidian-kensaku-license*
 

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -154,6 +154,22 @@ picker ~
 	telescope-egrepify.nvim, which provides better regex
 	highlighting.
 
+						    *obsidian-kensaku-previewer*
+previewer ~
+	Type: `fun(): table`
+	Default: `nil`
+
+	A function that returns a custom telescope previewer. When
+	set, it is used for all picker commands.
+
+	Example with md-render.nvim: >lua
+	    {
+	      previewer = function()
+	        return require("md-render.telescope").previewer()
+	      end,
+	    }
+<
+
 ==============================================================================
 LICENSE						      *obsidian-kensaku-license*
 

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -13,15 +13,15 @@ License						      |obsidian-kensaku-license|
 ==============================================================================
 INTRODUCTION					 *obsidian-kensaku-introduction*
 
-obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|.
-It provides two commands:
+obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|. It
+provides two commands:
 
 - |:ObsidianKensaku| searches note contents (like |:ObsidianSearch|)
 - |:ObsidianQuickKensaku| searches notes by file name
   (like |:ObsidianQuickSwitch|)
 
-Romaji input is converted to regex using kensaku.vim or cmigemo, enabling
-you to search Japanese text without switching input methods.
+Romaji input is converted to regex using kensaku.vim or cmigemo, enabling you
+to search Japanese text without switching input methods.
 
 ==============================================================================
 REQUIREMENTS					 *obsidian-kensaku-requirements*
@@ -89,16 +89,15 @@ COMMANDS					     *obsidian-kensaku-commands*
 
 :ObsidianKensaku [query]				      *:ObsidianKensaku*
 
-	Search vault note contents with Romaji. Works like
-	|:ObsidianSearch| but converts Romaji input to regex for
-	Japanese text matching. If [query] is given, it is used as the
-	initial search query.
+	Search vault note contents with Romaji. Works like |:ObsidianSearch| but
+	converts Romaji input to regex for Japanese text matching. If [query]
+	is given, it is used as the initial search query.
 
 :ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
 
 	Search vault notes by file name with Romaji. Works like
-	|:ObsidianQuickSwitch| but converts Romaji input to regex for
-	Japanese text matching.
+	|:ObsidianQuickSwitch| but converts Romaji input to regex for Japanese
+	text matching.
 
 ==============================================================================
 OPTIONS						      *obsidian-kensaku-options*
@@ -142,8 +141,8 @@ migemo_dict_path ~
 	Default: (auto-detected)
 
 	Path to the migemo dictionary file. Only used when
-	|obsidian-kensaku-query_filter| is `"cmigemo"`. If not
-	specified, the plugin will search for it automatically.
+	|obsidian-kensaku-query_filter| is `"cmigemo"`. If not specified, the
+	plugin will search for it automatically.
 
 						       *obsidian-kensaku-picker*
 picker ~
@@ -151,17 +150,16 @@ picker ~
 	Default: `"default"`
 
 	The telescope picker to use. Set to `"egrepify"` to use
-	telescope-egrepify.nvim, which provides better regex
-	highlighting.
+	telescope-egrepify.nvim, which provides better regex highlighting.
 
 						    *obsidian-kensaku-previewer*
 previewer ~
 	Type: `fun(): table`
 	Default: `nil`
 
-	A function that returns a custom telescope previewer. When
-	set, it is used for all picker commands. For example,
-	md-render.nvim can render Markdown in the preview window.
+	A function that returns a custom telescope previewer. When set, it is
+	used for all picker commands. For example, md-render.nvim can render
+	Markdown in the preview window.
 
 	  https://github.com/delphinus/md-render.nvim
 

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -160,9 +160,12 @@ previewer ~
 	Default: `nil`
 
 	A function that returns a custom telescope previewer. When
-	set, it is used for all picker commands.
+	set, it is used for all picker commands. For example,
+	md-render.nvim can render Markdown in the preview window.
 
-	Example with md-render.nvim: >lua
+	  https://github.com/delphinus/md-render.nvim
+
+	Example: >lua
 	    {
 	      previewer = function()
 	        return require("md-render.telescope").previewer()

--- a/lua/obsidian-kensaku/config.lua
+++ b/lua/obsidian-kensaku/config.lua
@@ -6,12 +6,14 @@ local filters = require "obsidian-kensaku.filters"
 ---@field cmigemo_executable? string default: "cmigemo"
 ---@field migemo_dict_path? string default: see README
 ---@field picker? "default"|"egrepify" default: "default"
+---@field previewer? fun(): table function that returns a telescope previewer
 ---@field query_filter? "kensaku"|"cmigemo"|fun(query: string): string default: "kensaku"
 
 ---@class obsidian-kensaku.config
 ---@field cmigemo_executable string
 ---@field migemo_dict_path string
 ---@field picker "default"|"egrepify"
+---@field previewer? fun(): table
 ---@field query_filter fun(query: string): string
 local config = {}
 
@@ -73,6 +75,7 @@ config.normalize = (function()
     end
 
     config.picker = options.picker
+    config.previewer = options.previewer
 
     return config
   end

--- a/lua/obsidian-kensaku/picker.lua
+++ b/lua/obsidian-kensaku/picker.lua
@@ -140,6 +140,7 @@ KensakuPicker.find_files = function(self, opts)
   telescope_builtin.find_files {
     prompt_title = prompt_title,
     cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
+    previewer = config.previewer and config.previewer() or nil,
     find_command = self:_build_find_cmd(),
     sorter = require "obsidian-kensaku.regex_sorter",
     on_input_filter_cb = function(prompt)

--- a/lua/obsidian-kensaku/picker.lua
+++ b/lua/obsidian-kensaku/picker.lua
@@ -189,10 +189,13 @@ KensakuPicker.grep = function(self, opts)
     egrepify = ext.egrepify
   end
 
+  local previewer = config.previewer and config.previewer() or nil
+
   if opts.query and string.len(opts.query) > 0 then
     telescope_builtin.grep_string {
       prompt_title = prompt_title,
       cwd = tostring(cwd),
+      previewer = previewer,
       vimgrep_arguments = self:_build_grep_cmd(),
       search = config.query_filter(opts.query),
       attach_mappings = attach_mappings,
@@ -202,6 +205,7 @@ KensakuPicker.grep = function(self, opts)
     picker {
       prompt_title = prompt_title,
       cwd = tostring(cwd),
+      previewer = previewer,
       vimgrep_arguments = self:_build_grep_cmd(),
       attach_mappings = attach_mappings,
       ---@param prompt string


### PR DESCRIPTION
## Summary

- Add `opts.previewer` to setup options — a function that returns a telescope previewer
- When provided, the previewer is passed to `grep_string`, `live_grep`, and `egrepify` pickers
- Enables integration with custom previewers like `md-render.nvim` without monkey-patching

## Usage

```lua
require("obsidian-kensaku").setup({
  picker = "egrepify",
  previewer = function()
    return require("md-render.telescope").previewer()
  end,
})
```

## Test plan

- [ ] `:ObsidianKensaku` with `previewer` option uses custom previewer
- [ ] `:ObsidianKensaku` without `previewer` option uses default previewer
- [ ] Works with both `egrepify` and default `live_grep` pickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)