### PR TITLE
Support obsidian-nvim/obsidian.nvim fork (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,23 @@
 
 <img alt="demo-egrepify" width="640" src="demo-egrepify.png">
 
-Search the vault with Romaji powered by [epwalsh/obsidian.nvim][].
+Search the vault with Romaji powered by [obsidian-nvim/obsidian.nvim][].
 
-ローマ字を使って [epwalsh/obsidian.nvim][] の文書を検索します。
+ローマ字を使って [obsidian-nvim/obsidian.nvim][] の文書を検索します。
+
+[obsidian-nvim/obsidian.nvim]: https://github.com/obsidian-nvim/obsidian.nvim
+
+> [!IMPORTANT]
+> v3 onwards targets the [obsidian-nvim/obsidian.nvim][] fork only. If you are
+> still on the archived [epwalsh/obsidian.nvim][], pin to the v2 line
+> (`version = "^2.0"`).
 
 [epwalsh/obsidian.nvim]: https://github.com/epwalsh/obsidian.nvim
 
 ## What's this?
 
 This plugin adds a command `:ObsidianKensaku`. This command looks like
-`:ObsidianSearch` but you can use Romaji to search the vault.
+`:Obsidian search` but you can use Romaji to search the vault.
 
 Romaji input is converted to regex using [delphinus/luamigemo][] (a pure Lua
 migemo engine). No external binaries or separate processes are required.
@@ -20,12 +27,12 @@ migemo engine). No external binaries or separate processes are required.
 
 ## Requirements
 
-* [epwalsh/obsidian.nvim][]
+* [obsidian-nvim/obsidian.nvim][]
 * [delphinus/luamigemo][] (dictionary bundled — no extra download needed)
 * [nvim-telescope/telescope.nvim][]
-  - obsidian.nvim supports telescope, [ibhagwan/fzf-lua][] and
-    [echasnovski/mini.pick][], but obsidian-kensaku.nvim supports telescope.nvim
-    only.
+  - obsidian.nvim supports telescope, [ibhagwan/fzf-lua][],
+    [echasnovski/mini.pick][], and [folke/snacks.nvim][], but
+    obsidian-kensaku.nvim supports telescope.nvim only.
 * [fdschmidt93/telescope-egrepify.nvim][] _(optional)_
   - telescope has a bug (https://github.com/nvim-telescope/telescope.nvim/issues/2272)
     that it cannot highlight properly with string matched by regex. I recommend
@@ -34,20 +41,22 @@ migemo engine). No external binaries or separate processes are required.
 [nvim-telescope/telescope.nvim]: https://github.com/nvim-telescope/telescope.nvim
 [ibhagwan/fzf-lua]: https://github.com/ibhagwan/fzf-lua
 [echasnovski/mini.pick]: https://github.com/echasnovski/mini.pick
+[folke/snacks.nvim]: https://github.com/folke/snacks.nvim
 [fdschmidt93/telescope-egrepify.nvim]: https://github.com/fdschmidt93/telescope-egrepify.nvim
 
 ## Install
 
 ### Pinning to a stable version
 
-This plugin uses [SemVer](https://semver.org/). If you want to avoid breaking
-changes, add `version = "*"` to your lazy.nvim spec. This tells lazy.nvim to
-use the latest tagged release instead of the `main` branch:
+This plugin uses [SemVer](https://semver.org/). The v3 line targets
+[obsidian-nvim/obsidian.nvim][]; the v2 line targets the archived
+[epwalsh/obsidian.nvim][]. Pin accordingly:
 
 ```lua
 {
   "delphinus/obsidian-kensaku.nvim",
-  version = "*",
+  version = "^3.0", -- for obsidian-nvim/obsidian.nvim
+  -- version = "^2.0", -- for epwalsh/obsidian.nvim
 }
 ```
 
@@ -56,74 +65,44 @@ use the latest tagged release instead of the `main` branch:
 ```lua
 -- example for lazy.nvim
 {
-  "epwalsh/obsidian.nvim",
+  "delphinus/obsidian-kensaku.nvim",
+  version = "^3.0",
+  cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
   dependencies = {
-    "nvim-lua/plenary.nvim",
-    {
-      "delphinus/obsidian-kensaku.nvim",
-      version = "*",
-      dependencies = { { "delphinus/luamigemo", version = "*" } },
-    },
+    "obsidian-nvim/obsidian.nvim",
+    { "delphinus/luamigemo", version = "*" },
   },
-  opts = {
-    callbacks = {
-      post_setup = function(client)
-        require "obsidian-kensaku"(client),
-      end,
-    },
-  },
+  opts = {},
 }
 ```
 
-> [!IMPORTANT]
-> Remember to call this plugin in `opts.callbacks.post_setup`.
-
-If you want to customize options, call `setup` or write them in `opts` (for
-[lazy.nvim](https://github.com/folke/lazy.nvim)).
+`opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for you.
+For other plugin managers, call `setup` manually:
 
 ```lua
--- example for lazy.nvim
-{
-  "epwalsh/obsidian.nvim",
-  dependencies = {
-    "nvim-lua/plenary.nvim",
-    {
-      "delphinus/obsidian-kensaku.nvim",
-      version = "*",
-      dependencies = { { "delphinus/luamigemo", version = "*" } },
-      opts = {
-        picker = "egrepify",
-      },
-      --- for other plugin managers
-      -- config = function()
-      --   require("obsidian-kensaku").setup {
-      --     picker = "egrepify",
-      --   }
-      -- end,
-    },
-  },
-  opts = {
-    callbacks = {
-      post_setup = function(client)
-        require "obsidian-kensaku"(client),
-      end,
-    },
-  },
+require("obsidian-kensaku").setup {
+  picker = "egrepify",
 }
 ```
+
+> [!NOTE]
+> v2 required wiring the plugin from inside `opts.callbacks.post_setup` of
+> obsidian.nvim. v3 drops that — `setup()` is self-contained, and obsidian.nvim
+> only needs to have been initialized by the time you invoke a command. Listing
+> `obsidian-nvim/obsidian.nvim` as a dependency (as above) handles that for you.
 
 ## Commands
 
 ### `:ObsidianKensaku`
 
-Open the picker like `:ObsidianSearch`. You can search note **contents** with
-Romaji and do the same things as in `:ObsidianSearch`.
+Open the picker like `:Obsidian search`. You can search note **contents** with
+Romaji and do the same things as in `:Obsidian search`.
 
 ### `:ObsidianQuickKensaku`
 
-Open the picker like `:ObsidianQuickSwitch`. You can search notes by **file
+Open the picker like `:Obsidian quick_switch`. You can search notes by **file
 name** with Romaji. This is the kensaku-powered equivalent of
-`:ObsidianQuickSwitch`.
+`:Obsidian quick_switch`.
 
 ## Options
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -16,9 +16,9 @@
 obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加するプラグイン
 です。以下の二つのコマンドを提供します。
 
-- |:ObsidianKensaku| ノートの内容を検索 (|:ObsidianSearch| 相当)
+- |:ObsidianKensaku| ノートの内容を検索 (`:Obsidian search` 相当)
 - |:ObsidianQuickKensaku| ファイル名でノートを検索
-  (|:ObsidianQuickSwitch| 相当)
+  (`:Obsidian quick_switch` 相当)
 
 ローマ字入力を luamigemo (純 Lua migemo エンジン) で正規表現に変換し、入力メ
 ソッドを切り替えずに日本語テキストを検索できます。外部バイナリや別プロセスは不
@@ -26,12 +26,19 @@ obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加�
 
   https://github.com/delphinus/luamigemo
 
+注意: v3 以降は obsidian-nvim/obsidian.nvim fork のみを対象としています。
+アーカイブされた epwalsh/obsidian.nvim をまだ使っている場合は v2 系
+(`version = "^2.0"`) を pin してください。
+
+  https://github.com/obsidian-nvim/obsidian.nvim
+  https://github.com/epwalsh/obsidian.nvim
+
 ==============================================================================
 必要なもの					 *obsidian-kensaku-requirements*
 
 - Neovim >= 0.10.0
-- epwalsh/obsidian.nvim
-    https://github.com/epwalsh/obsidian.nvim
+- obsidian-nvim/obsidian.nvim
+    https://github.com/obsidian-nvim/obsidian.nvim
 - delphinus/luamigemo (辞書内蔵 — 追加ダウンロード不要)
     https://github.com/delphinus/luamigemo
 - nvim-telescope/telescope.nvim
@@ -44,75 +51,55 @@ obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加�
 
 安定版を使う ~
 
-このプラグインは SemVer に従います。破壊的な変更を避けたい場合は、lazy.nvim の
-spec に `version = "*"` を追加してください。これにより `main` ブランチではなく、最
-新のタグ付きリリースが使用されます: >lua
+このプラグインは SemVer に従います。v3 系は obsidian-nvim/obsidian.nvim を、
+v2 系はアーカイブされた epwalsh/obsidian.nvim を対象とします。使い分けて pin
+してください: >lua
     {
       "delphinus/obsidian-kensaku.nvim",
-      version = "*",
+      version = "^3.0", -- obsidian-nvim/obsidian.nvim 向け
+      -- version = "^2.0", -- epwalsh/obsidian.nvim 向け
     }
 <
 
 lazy.nvim 設定例: >lua
     {
-      "epwalsh/obsidian.nvim",
+      "delphinus/obsidian-kensaku.nvim",
+      version = "^3.0",
+      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
       dependencies = {
-        "nvim-lua/plenary.nvim",
-        {
-          "delphinus/obsidian-kensaku.nvim",
-          version = "*",
-          dependencies = { { "delphinus/luamigemo", version = "*" } },
-        },
+        "obsidian-nvim/obsidian.nvim",
+        { "delphinus/luamigemo", version = "*" },
       },
-      opts = {
-        callbacks = {
-          post_setup = function(client)
-            require "obsidian-kensaku"(client)
-          end,
-        },
-      },
+      opts = {},
     }
 <
-重要: `opts.callbacks.post_setup` 内で呼び出す必要があります。
-
-オプションをカスタマイズする場合: >lua
-    {
-      "epwalsh/obsidian.nvim",
-      dependencies = {
-        "nvim-lua/plenary.nvim",
-        {
-          "delphinus/obsidian-kensaku.nvim",
-          version = "*",
-          dependencies = { { "delphinus/luamigemo", version = "*" } },
-          opts = {
-            picker = "egrepify",
-          },
-        },
-      },
-      opts = {
-        callbacks = {
-          post_setup = function(client)
-            require "obsidian-kensaku"(client)
-          end,
-        },
-      },
+`opts = {}` を指定すると lazy.nvim が自動で
+`require("obsidian-kensaku").setup()` を呼び出します。他のプラグインマネージャ
+を使う場合は手動で `setup` を呼んでください: >lua
+    require("obsidian-kensaku").setup {
+      picker = "egrepify",
     }
 <
+注意: v2 では obsidian.nvim の `opts.callbacks.post_setup` から
+`require "obsidian-kensaku"(client)` を呼び出す必要がありました。v3 ではこの
+手順は廃止され、`setup()` は単体で完結します。コマンド呼び出し時点までに
+obsidian.nvim が初期化されていれば動作するため、上記例のように
+`obsidian-nvim/obsidian.nvim` を `dependencies` に並べておけば十分です。
 
 ==============================================================================
 コマンド					     *obsidian-kensaku-commands*
 
 :ObsidianKensaku [query]				      *:ObsidianKensaku*
 
-	ローマ字で vault のノート内容を検索します。 |:ObsidianSearch| と同様に動
-	作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッチング
-	します。[query] を指定すると初期検索クエリとして使用されます。
+	ローマ字で vault のノート内容を検索します。 `:Obsidian search` と同様
+	に動作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッ
+	チングします。[query] を指定すると初期検索クエリとして使用されます。
 
 :ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
 
-	ローマ字でファイル名からノートを検索します。 |:ObsidianQuickSwitch| と同
-	様に動作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッ
-	チングします。
+	ローマ字でファイル名からノートを検索します。 `:Obsidian quick_switch`
+	と同様に動作しますが、ローマ字入力を正規表現に変換して日本語テキスト
+	をマッチングします。
 
 ==============================================================================
 オプション					      *obsidian-kensaku-options*

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -16,9 +16,9 @@ INTRODUCTION				         *obsidian-kensaku-introduction*
 obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|. It
 provides two commands:
 
-- |:ObsidianKensaku| searches note contents (like |:ObsidianSearch|)
+- |:ObsidianKensaku| searches note contents (like `:Obsidian search`)
 - |:ObsidianQuickKensaku| searches notes by file name
-  (like |:ObsidianQuickSwitch|)
+  (like `:Obsidian quick_switch`)
 
 Romaji input is converted to regex using luamigemo (a pure Lua migemo engine),
 enabling you to search Japanese text without switching input methods. No
@@ -26,12 +26,19 @@ external binaries or separate processes are required.
 
   https://github.com/delphinus/luamigemo
 
+NOTE: v3 onwards targets the obsidian-nvim/obsidian.nvim fork only. If you are
+still on the archived epwalsh/obsidian.nvim, pin to the v2 line
+(`version = "^2.0"`).
+
+  https://github.com/obsidian-nvim/obsidian.nvim
+  https://github.com/epwalsh/obsidian.nvim
+
 ==============================================================================
 REQUIREMENTS				         *obsidian-kensaku-requirements*
 
 - Neovim >= 0.10.0
-- epwalsh/obsidian.nvim
-    https://github.com/epwalsh/obsidian.nvim
+- obsidian-nvim/obsidian.nvim
+    https://github.com/obsidian-nvim/obsidian.nvim
 - delphinus/luamigemo (dictionary bundled — no extra download needed)
     https://github.com/delphinus/luamigemo
 - nvim-telescope/telescope.nvim
@@ -44,75 +51,53 @@ INSTALLATION				              *obsidian-kensaku-install*
 
 PINNING TO A STABLE VERSION ~
 
-This plugin uses SemVer. If you want to avoid breaking changes, you can pin to
-a stable release by adding `version = "*"` to your lazy.nvim spec; lazy.nvim will
-then use the latest tagged release instead of the `main` branch: >lua
+This plugin uses SemVer. The v3 line targets obsidian-nvim/obsidian.nvim; the
+v2 line targets the archived epwalsh/obsidian.nvim. Pin accordingly: >lua
     {
       "delphinus/obsidian-kensaku.nvim",
-      version = "*",
+      version = "^3.0", -- for obsidian-nvim/obsidian.nvim
+      -- version = "^2.0", -- for epwalsh/obsidian.nvim
     }
 <
 
 Example configuration with lazy.nvim: >lua
     {
-      "epwalsh/obsidian.nvim",
+      "delphinus/obsidian-kensaku.nvim",
+      version = "^3.0",
+      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
       dependencies = {
-        "nvim-lua/plenary.nvim",
-        {
-          "delphinus/obsidian-kensaku.nvim",
-          version = "*",
-          dependencies = { { "delphinus/luamigemo", version = "*" } },
-        },
+        "obsidian-nvim/obsidian.nvim",
+        { "delphinus/luamigemo", version = "*" },
       },
-      opts = {
-        callbacks = {
-          post_setup = function(client)
-            require "obsidian-kensaku"(client)
-          end,
-        },
-      },
+      opts = {},
     }
 <
-IMPORTANT: You must call this plugin in `opts.callbacks.post_setup`.
-
-If you want to customize options: >lua
-    {
-      "epwalsh/obsidian.nvim",
-      dependencies = {
-        "nvim-lua/plenary.nvim",
-        {
-          "delphinus/obsidian-kensaku.nvim",
-          version = "*",
-          dependencies = { { "delphinus/luamigemo", version = "*" } },
-          opts = {
-            picker = "egrepify",
-          },
-        },
-      },
-      opts = {
-        callbacks = {
-          post_setup = function(client)
-            require "obsidian-kensaku"(client)
-          end,
-        },
-      },
+`opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for
+you. For other plugin managers, call `setup` manually: >lua
+    require("obsidian-kensaku").setup {
+      picker = "egrepify",
     }
 <
+NOTE: v2 required wiring the plugin from inside `opts.callbacks.post_setup`
+of obsidian.nvim. v3 drops that — `setup()` is self-contained, and
+obsidian.nvim only needs to have been initialized by the time you invoke a
+command. Listing `obsidian-nvim/obsidian.nvim` as a dependency (as above)
+handles that for you.
 
 ==============================================================================
 COMMANDS				             *obsidian-kensaku-commands*
 
 :ObsidianKensaku [query]				      *:ObsidianKensaku*
 
-	Search vault note contents with Romaji. Works like |:ObsidianSearch| but
-	converts Romaji input to regex for Japanese text matching. If [query]
-	is given, it is used as the initial search query.
+	Search vault note contents with Romaji. Works like `:Obsidian search`
+	but converts Romaji input to regex for Japanese text matching. If
+	[query] is given, it is used as the initial search query.
 
 :ObsidianQuickKensaku				         *:ObsidianQuickKensaku*
 
 	Search vault notes by file name with Romaji. Works like
-	|:ObsidianQuickSwitch| but converts Romaji input to regex for Japanese
-	text matching.
+	`:Obsidian quick_switch` but converts Romaji input to regex for
+	Japanese text matching.
 
 ==============================================================================
 OPTIONS					              *obsidian-kensaku-options*

--- a/lua/obsidian-kensaku.lua
+++ b/lua/obsidian-kensaku.lua
@@ -1,30 +1,23 @@
 ---@class obsidian-kensaku
 ---@field setup_called boolean
 ---@field setup fun(opts?: obsidian-kensaku.config.SetupOpts)
----@overload fun(client: obsidian.Client)
 
 return setmetatable({ setup_called = false }, {
-  ---@param client obsidian.Client
-  __call = function(self, client)
-    if not self.setup_called then
-      self.setup()
-    end
-    vim.api.nvim_create_user_command("ObsidianKensaku", function(data)
-      local picker = require("obsidian-kensaku.picker").new(client)
-      picker:grep_notes { query = data.args }
-    end, { nargs = "?", desc = "Search vault with migemo" })
-    vim.api.nvim_create_user_command("ObsidianQuickKensaku", function(data)
-      local picker = require("obsidian-kensaku.picker").new(client)
-      picker:find_notes()
-    end, { nargs = "?", desc = "Search vault with migemo" })
-  end,
   ---@param key string
   __index = function(self, key)
     if key == "setup" then
-      ---@param opts obsidian-kensaku.config.SetupOpts
+      ---@param opts? obsidian-kensaku.config.SetupOpts
       return function(opts)
         require("obsidian-kensaku.config").normalize(opts)
-        self.setup_called = true
+        if not self.setup_called then
+          vim.api.nvim_create_user_command("ObsidianKensaku", function(data)
+            require("obsidian-kensaku.picker").grep_notes { query = data.args }
+          end, { nargs = "?", desc = "Search vault with migemo" })
+          vim.api.nvim_create_user_command("ObsidianQuickKensaku", function()
+            require("obsidian-kensaku.picker").find_notes()
+          end, { nargs = 0, desc = "Search vault filenames with migemo" })
+          self.setup_called = true
+        end
       end
     end
     error("Invalid key: " .. key)

--- a/lua/obsidian-kensaku/picker.lua
+++ b/lua/obsidian-kensaku/picker.lua
@@ -4,19 +4,13 @@ local telescope_actions = require "telescope.actions"
 local actions_state = require "telescope.actions.state"
 
 local Path = require "obsidian.path"
-local abc = require "obsidian.abc"
-local TelescopePicker = require "obsidian.pickers._telescope"
+local Picker = require "obsidian.picker"
 local log = require "obsidian.log"
+local search = require "obsidian.search"
 
 local config = require "obsidian-kensaku.config"
 
----@class obsidian.pickers.KensakuPicker : obsidian.pickers.TelescopePicker
-local KensakuPicker = abc.new_class({
-  ---@diagnostic disable-next-line: unused-local
-  __tostring = function(self)
-    return "KensakuPicker()"
-  end,
-}, TelescopePicker)
+local M = {}
 
 ---@param prompt_bufnr integer
 ---@param keep_open boolean|?
@@ -43,8 +37,6 @@ local function get_query(prompt_bufnr, keep_open, initial_query)
       telescope_actions.close(prompt_bufnr)
     end
     return query
-  else
-    return nil
   end
 end
 
@@ -75,11 +67,9 @@ local function get_selected(prompt_bufnr, keep_open, allow_multiple)
   end
 end
 
+---@param map fun(modes: string[], key: string, callback: fun(prompt_bufnr: integer))
 ---@param opts { entry_key: string|?, callback: fun(path: string)|?, allow_multiple: boolean|?, query_mappings: obsidian.PickerMappingTable|?, selection_mappings: obsidian.PickerMappingTable|?, initial_query: string|? }
 local function attach_picker_mappings(map, opts)
-  -- Docs for telescope actions:
-  -- https://github.com/nvim-telescope/telescope.nvim/blob/master/lua/telescope/actions/init.lua
-
   local function entry_to_value(entry)
     if opts.entry_key then
       return entry[opts.entry_key]
@@ -127,21 +117,24 @@ local function attach_picker_mappings(map, opts)
   end
 end
 
----@param opts obsidian.PickerFindOpts|? Options.
-KensakuPicker.find_files = function(self, opts)
+---@param opts? { dir?: string|obsidian.Path, prompt_title?: string, callback?: fun(path: string), query_mappings?: obsidian.PickerMappingTable, selection_mappings?: obsidian.PickerMappingTable, no_default_mappings?: boolean }
+M.find_notes = function(opts)
   opts = opts or {}
 
-  local prompt_title = self:_build_prompt {
-    prompt_title = opts.prompt_title,
-    query_mappings = opts.query_mappings,
-    selection_mappings = opts.selection_mappings,
-  }
+  local query_mappings, selection_mappings
+  if not opts.no_default_mappings then
+    query_mappings = opts.query_mappings or Picker._note_query_mappings()
+    selection_mappings = opts.selection_mappings or Picker._note_selection_mappings()
+  else
+    query_mappings = opts.query_mappings
+    selection_mappings = opts.selection_mappings
+  end
 
   telescope_builtin.find_files {
-    prompt_title = prompt_title,
-    cwd = opts.dir and tostring(opts.dir) or tostring(self.client.dir),
+    prompt_title = opts.prompt_title or "Notes",
+    cwd = opts.dir and tostring(opts.dir) or tostring(Obsidian.dir),
     previewer = config.previewer and config.previewer() or nil,
-    find_command = self:_build_find_cmd(),
+    find_command = search.build_find_cmd(nil, nil, { include_non_markdown = false }),
     sorter = require "obsidian-kensaku.regex_sorter",
     on_input_filter_cb = function(prompt)
       local migemo = require "luamigemo"
@@ -153,32 +146,35 @@ KensakuPicker.find_files = function(self, opts)
       attach_picker_mappings(map, {
         entry_key = "path",
         callback = opts.callback,
-        query_mappings = opts.query_mappings,
-        selection_mappings = opts.selection_mappings,
+        query_mappings = query_mappings,
+        selection_mappings = selection_mappings,
       })
       return true
     end,
   }
 end
 
----@param opts obsidian.PickerGrepOpts|? Options.
-KensakuPicker.grep = function(self, opts)
+---@param opts? { dir?: string|obsidian.Path, query?: string, prompt_title?: string, callback?: fun(entry: table), query_mappings?: obsidian.PickerMappingTable, selection_mappings?: obsidian.PickerMappingTable, no_default_mappings?: boolean }
+M.grep_notes = function(opts)
   opts = opts or {}
 
-  local cwd = opts.dir and Path:new(opts.dir) or self.client.dir
+  local cwd = opts.dir and Path.new(opts.dir) or Obsidian.dir
 
-  local prompt_title = self:_build_prompt {
-    prompt_title = opts.prompt_title,
-    query_mappings = opts.query_mappings,
-    selection_mappings = opts.selection_mappings,
-  }
+  local query_mappings, selection_mappings
+  if not opts.no_default_mappings then
+    query_mappings = opts.query_mappings or Picker._note_query_mappings()
+    selection_mappings = opts.selection_mappings or Picker._note_selection_mappings()
+  else
+    query_mappings = opts.query_mappings
+    selection_mappings = opts.selection_mappings
+  end
 
   local attach_mappings = function(_, map)
     attach_picker_mappings(map, {
       entry_key = "path",
       callback = opts.callback,
-      query_mappings = opts.query_mappings,
-      selection_mappings = opts.selection_mappings,
+      query_mappings = query_mappings,
+      selection_mappings = selection_mappings,
       initial_query = opts.query,
     })
     return true
@@ -194,13 +190,14 @@ KensakuPicker.grep = function(self, opts)
   end
 
   local previewer = config.previewer and config.previewer() or nil
+  local prompt_title = opts.prompt_title or "Grep notes"
 
   if opts.query and string.len(opts.query) > 0 then
     telescope_builtin.grep_string {
       prompt_title = prompt_title,
       cwd = tostring(cwd),
       previewer = previewer,
-      vimgrep_arguments = self:_build_grep_cmd(),
+      vimgrep_arguments = search.build_grep_cmd { fixed_strings = false },
       search = config.query_filter(opts.query),
       attach_mappings = attach_mappings,
     }
@@ -210,7 +207,7 @@ KensakuPicker.grep = function(self, opts)
       prompt_title = prompt_title,
       cwd = tostring(cwd),
       previewer = previewer,
-      vimgrep_arguments = self:_build_grep_cmd(),
+      vimgrep_arguments = search.build_grep_cmd { fixed_strings = false },
       attach_mappings = attach_mappings,
       ---@param prompt string
       ---@return { prompt: string }
@@ -221,14 +218,4 @@ KensakuPicker.grep = function(self, opts)
   end
 end
 
-KensakuPicker._build_grep_cmd = function(self)
-  local search = require "obsidian.search"
-  local search_opts = search.SearchOpts.from_tbl {
-    sort_by = self.client.opts.sort_by,
-    sort_reversed = self.client.opts.sort_reversed,
-    smart_case = true,
-  }
-  return search.build_grep_cmd(search_opts)
-end
-
-return KensakuPicker
+return M


### PR DESCRIPTION
## Summary

- Rewrite the picker for the [obsidian-nvim/obsidian.nvim](https://github.com/obsidian-nvim/obsidian.nvim) fork's new API (the upstream `epwalsh/obsidian.nvim` is now archived).
- Drop the `obsidian.abc` class-inheritance pattern (removed in obsidian-nvim/obsidian.nvim#493) and rebuild the picker as a plain module.
- Read the picker module from `obsidian.picker` (singular) instead of the deprecated `obsidian.pickers._telescope`.
- Resolve the vault directory via the `Obsidian` global; the old `client.dir` path no longer exists.
- Pass `fixed_strings = false` to `search.build_grep_cmd` so the migemo-generated regex is interpreted as a pattern, not a literal string. (The fork now defaults this to `true`, which silently broke `:ObsidianKensaku`.)
- Borrow default note mappings from `Picker._note_*_mappings()` so `insert_link` / `new_note` continue to work.
- Drop the `__call(client)` form and the `post_setup` wiring it required. `setup()` is now self-contained and registers the user commands itself; lazy.nvim users can rely on `opts = {}` to invoke it automatically.

## Breaking changes

v3 onwards targets `obsidian-nvim/obsidian.nvim` only. Users still on the archived `epwalsh/obsidian.nvim` should pin to the v2 line (`version = "^2.0"`). The `require("obsidian-kensaku")(client)` call inside `opts.callbacks.post_setup` is no longer needed and should be removed.

## Test plan

- [x] `:ObsidianQuickKensaku` opens the file-name picker and migemo input matches Japanese filenames
- [x] `:ObsidianKensaku` opens the grep picker and migemo input matches note contents
- [x] No `legacy_commands is deprecated` warning is shown when the host plugin sets `legacy_commands = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)