### PR TITLE
Register :Obsidian kensaku / quick_kensaku subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ Search the vault with Romaji powered by [obsidian-nvim/obsidian.nvim][].
 
 ## What's this?
 
-This plugin adds a command `:ObsidianKensaku`. This command looks like
+This plugin adds a command `:Obsidian kensaku`. This command looks like
 `:Obsidian search` but you can use Romaji to search the vault.
 
 Romaji input is converted to regex using [delphinus/luamigemo][] (a pure Lua
 migemo engine). No external binaries or separate processes are required.
+
+> [!NOTE]
+> The top-level `:ObsidianKensaku` / `:ObsidianQuickKensaku` user commands
+> remain as aliases for compatibility, and will be removed in v4.0.0.
 
 [delphinus/luamigemo]: https://github.com/delphinus/luamigemo
 
@@ -66,8 +70,8 @@ This plugin uses [SemVer](https://semver.org/). The v3 line targets
 -- example for lazy.nvim
 {
   "delphinus/obsidian-kensaku.nvim",
-  version = "^3.0",
-  cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+  version = "^3.1",
+  cmd = "Obsidian",
   dependencies = {
     "obsidian-nvim/obsidian.nvim",
     { "delphinus/luamigemo", version = "*" },
@@ -75,6 +79,10 @@ This plugin uses [SemVer](https://semver.org/). The v3 line targets
   opts = {},
 }
 ```
+
+`cmd = "Obsidian"` makes lazy.nvim load both this plugin and obsidian.nvim on
+the first `:Obsidian ...` invocation, so the `:Obsidian kensaku` /
+`:Obsidian quick_kensaku` subcommands are registered before they are dispatched.
 
 `opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for you.
 For other plugin managers, call `setup` manually:
@@ -93,16 +101,20 @@ require("obsidian-kensaku").setup {
 
 ## Commands
 
-### `:ObsidianKensaku`
+### `:Obsidian kensaku`
 
 Open the picker like `:Obsidian search`. You can search note **contents** with
 Romaji and do the same things as in `:Obsidian search`.
 
-### `:ObsidianQuickKensaku`
+Also available as `:ObsidianKensaku` (legacy; removed in v4.0.0).
+
+### `:Obsidian quick_kensaku`
 
 Open the picker like `:Obsidian quick_switch`. You can search notes by **file
 name** with Romaji. This is the kensaku-powered equivalent of
 `:Obsidian quick_switch`.
+
+Also available as `:ObsidianQuickKensaku` (legacy; removed in v4.0.0).
 
 ## Options
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -14,11 +14,14 @@
 はじめに					 *obsidian-kensaku-introduction*
 
 obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加するプラグイン
-です。以下の二つのコマンドを提供します。
+です。 `:Obsidian` の以下二つのサブコマンドを提供します。
 
-- |:ObsidianKensaku| ノートの内容を検索 (`:Obsidian search` 相当)
-- |:ObsidianQuickKensaku| ファイル名でノートを検索
+- `:Obsidian kensaku` ノートの内容を検索 (`:Obsidian search` 相当)
+- `:Obsidian quick_kensaku` ファイル名でノートを検索
   (`:Obsidian quick_switch` 相当)
+
+トップレベルのユーザコマンド |:ObsidianKensaku| / |:ObsidianQuickKensaku| も
+エイリアスとして残してありますが v4.0.0 で削除予定です。
 
 ローマ字入力を luamigemo (純 Lua migemo エンジン) で正規表現に変換し、入力メ
 ソッドを切り替えずに日本語テキストを検索できます。外部バイナリや別プロセスは不
@@ -64,8 +67,8 @@ v2 系はアーカイブされた epwalsh/obsidian.nvim を対象とします。
 lazy.nvim 設定例: >lua
     {
       "delphinus/obsidian-kensaku.nvim",
-      version = "^3.0",
-      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+      version = "^3.1",
+      cmd = "Obsidian",
       dependencies = {
         "obsidian-nvim/obsidian.nvim",
         { "delphinus/luamigemo", version = "*" },
@@ -73,6 +76,10 @@ lazy.nvim 設定例: >lua
       opts = {},
     }
 <
+`cmd = "Obsidian"` を指定することで、 lazy.nvim は `:Obsidian ...` を
+初めて呼んだときに本プラグインと obsidian.nvim を両方ロードします。これに
+より `:Obsidian kensaku` / `:Obsidian quick_kensaku` サブコマンドが
+ディスパッチ前に登録された状態になります。
 `opts = {}` を指定すると lazy.nvim が自動で
 `require("obsidian-kensaku").setup()` を呼び出します。他のプラグインマネージャ
 を使う場合は手動で `setup` を呼んでください: >lua
@@ -89,17 +96,21 @@ obsidian.nvim が初期化されていれば動作するため、上記例のよ
 ==============================================================================
 コマンド					     *obsidian-kensaku-commands*
 
-:ObsidianKensaku [query]				      *:ObsidianKensaku*
+:Obsidian kensaku [query]				      *:ObsidianKensaku*
 
 	ローマ字で vault のノート内容を検索します。 `:Obsidian search` と同様
 	に動作しますが、ローマ字入力を正規表現に変換して日本語テキストをマッ
 	チングします。[query] を指定すると初期検索クエリとして使用されます。
 
-:ObsidianQuickKensaku					 *:ObsidianQuickKensaku*
+	`:ObsidianKensaku` でも呼び出せます (legacy 、 v4.0.0 で削除予定)。
+
+:Obsidian quick_kensaku					 *:ObsidianQuickKensaku*
 
 	ローマ字でファイル名からノートを検索します。 `:Obsidian quick_switch`
 	と同様に動作しますが、ローマ字入力を正規表現に変換して日本語テキスト
 	をマッチングします。
+
+	`:ObsidianQuickKensaku` でも呼び出せます (legacy 、 v4.0.0 で削除予定)。
 
 ==============================================================================
 オプション					      *obsidian-kensaku-options*

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -14,11 +14,14 @@ License					              |obsidian-kensaku-license|
 INTRODUCTION				         *obsidian-kensaku-introduction*
 
 obsidian-kensaku.nvim adds Romaji search capabilities to |obsidian.nvim|. It
-provides two commands:
+provides two subcommands of `:Obsidian`:
 
-- |:ObsidianKensaku| searches note contents (like `:Obsidian search`)
-- |:ObsidianQuickKensaku| searches notes by file name
+- `:Obsidian kensaku` searches note contents (like `:Obsidian search`)
+- `:Obsidian quick_kensaku` searches notes by file name
   (like `:Obsidian quick_switch`)
+
+The top-level user commands |:ObsidianKensaku| / |:ObsidianQuickKensaku| are
+kept as aliases and will be removed in v4.0.0.
 
 Romaji input is converted to regex using luamigemo (a pure Lua migemo engine),
 enabling you to search Japanese text without switching input methods. No
@@ -63,8 +66,8 @@ v2 line targets the archived epwalsh/obsidian.nvim. Pin accordingly: >lua
 Example configuration with lazy.nvim: >lua
     {
       "delphinus/obsidian-kensaku.nvim",
-      version = "^3.0",
-      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+      version = "^3.1",
+      cmd = "Obsidian",
       dependencies = {
         "obsidian-nvim/obsidian.nvim",
         { "delphinus/luamigemo", version = "*" },
@@ -72,6 +75,10 @@ Example configuration with lazy.nvim: >lua
       opts = {},
     }
 <
+`cmd = "Obsidian"` makes lazy.nvim load both this plugin and obsidian.nvim
+on the first `:Obsidian ...` invocation, so the `:Obsidian kensaku` /
+`:Obsidian quick_kensaku` subcommands are registered before they are
+dispatched.
 `opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for
 you. For other plugin managers, call `setup` manually: >lua
     require("obsidian-kensaku").setup {
@@ -87,17 +94,21 @@ handles that for you.
 ==============================================================================
 COMMANDS				             *obsidian-kensaku-commands*
 
-:ObsidianKensaku [query]				      *:ObsidianKensaku*
+:Obsidian kensaku [query]				      *:ObsidianKensaku*
 
 	Search vault note contents with Romaji. Works like `:Obsidian search`
 	but converts Romaji input to regex for Japanese text matching. If
 	[query] is given, it is used as the initial search query.
 
-:ObsidianQuickKensaku				         *:ObsidianQuickKensaku*
+	Also available as `:ObsidianKensaku` (legacy; removed in v4.0.0).
+
+:Obsidian quick_kensaku				         *:ObsidianQuickKensaku*
 
 	Search vault notes by file name with Romaji. Works like
 	`:Obsidian quick_switch` but converts Romaji input to regex for
 	Japanese text matching.
+
+	Also available as `:ObsidianQuickKensaku` (legacy; removed in v4.0.0).
 
 ==============================================================================
 OPTIONS					              *obsidian-kensaku-options*

--- a/lua/obsidian-kensaku.lua
+++ b/lua/obsidian-kensaku.lua
@@ -2,6 +2,31 @@
 ---@field setup_called boolean
 ---@field setup fun(opts?: obsidian-kensaku.config.SetupOpts)
 
+local function register_commands()
+  local ok, obsidian_commands = pcall(require, "obsidian.commands")
+  if ok then
+    obsidian_commands.register("kensaku", {
+      nargs = "?",
+      func = function(data)
+        require("obsidian-kensaku.picker").grep_notes { query = data.args }
+      end,
+    })
+    obsidian_commands.register("quick_kensaku", {
+      nargs = 0,
+      func = function()
+        require("obsidian-kensaku.picker").find_notes()
+      end,
+    })
+  end
+
+  vim.api.nvim_create_user_command("ObsidianKensaku", function(data)
+    require("obsidian-kensaku.picker").grep_notes { query = data.args }
+  end, { nargs = "?", desc = "Search vault with migemo (legacy; use :Obsidian kensaku)" })
+  vim.api.nvim_create_user_command("ObsidianQuickKensaku", function()
+    require("obsidian-kensaku.picker").find_notes()
+  end, { nargs = 0, desc = "Search vault filenames with migemo (legacy; use :Obsidian quick_kensaku)" })
+end
+
 return setmetatable({ setup_called = false }, {
   ---@param key string
   __index = function(self, key)
@@ -10,12 +35,7 @@ return setmetatable({ setup_called = false }, {
       return function(opts)
         require("obsidian-kensaku.config").normalize(opts)
         if not self.setup_called then
-          vim.api.nvim_create_user_command("ObsidianKensaku", function(data)
-            require("obsidian-kensaku.picker").grep_notes { query = data.args }
-          end, { nargs = "?", desc = "Search vault with migemo" })
-          vim.api.nvim_create_user_command("ObsidianQuickKensaku", function()
-            require("obsidian-kensaku.picker").find_notes()
-          end, { nargs = 0, desc = "Search vault filenames with migemo" })
+          register_commands()
           self.setup_called = true
         end
       end


### PR DESCRIPTION
## Summary

- Register the two pickers as `:Obsidian kensaku` / `:Obsidian quick_kensaku` via the host plugin's `obsidian.commands.register()` API, so they line up with the built-in subcommands (`:Obsidian search`, `:Obsidian quick_switch`, …).
- Keep `:ObsidianKensaku` / `:ObsidianQuickKensaku` as aliases for v3.x users; mark them as legacy and slated for removal in v4.0.0.
- Recommend `cmd = "Obsidian"` in the lazy.nvim spec so both this plugin and obsidian.nvim load on first `:Obsidian ...` invocation, ensuring the subcommands are registered before dispatch.

## Test plan

- [x] `:Obsidian kensaku` opens the grep picker, migemo input matches Japanese contents
- [x] `:Obsidian quick_kensaku` opens the file-name picker, migemo input matches Japanese filenames
- [x] `:ObsidianKensaku` / `:ObsidianQuickKensaku` still work as aliases
- [x] No regression in setup-time behavior (idempotent, safe across reloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)