### PR TITLE
Picker dispatcher + multi-picker one-shot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,10 @@ migemo engine). No external binaries or separate processes are required.
 
 * [obsidian-nvim/obsidian.nvim][]
 * [delphinus/luamigemo][] (dictionary bundled — no extra download needed)
-* [nvim-telescope/telescope.nvim][]
-  - obsidian.nvim supports telescope, [ibhagwan/fzf-lua][],
-    [echasnovski/mini.pick][], and [folke/snacks.nvim][], but
-    obsidian-kensaku.nvim supports telescope.nvim only.
-* [fdschmidt93/telescope-egrepify.nvim][] _(optional)_
+* A picker supported by obsidian.nvim: [nvim-telescope/telescope.nvim][],
+  [ibhagwan/fzf-lua][], [folke/snacks.nvim][], or [echasnovski/mini.pick][].
+  See [Picker support](#picker-support) for the feature matrix.
+* [fdschmidt93/telescope-egrepify.nvim][] _(optional, telescope only)_
   - telescope has a bug (https://github.com/nvim-telescope/telescope.nvim/issues/2272)
     that it cannot highlight properly with string matched by regex. I recommend
     you to use telescope-egrepify for this.
@@ -47,6 +46,28 @@ migemo engine). No external binaries or separate processes are required.
 [echasnovski/mini.pick]: https://github.com/echasnovski/mini.pick
 [folke/snacks.nvim]: https://github.com/folke/snacks.nvim
 [fdschmidt93/telescope-egrepify.nvim]: https://github.com/fdschmidt93/telescope-egrepify.nvim
+
+## Picker support
+
+obsidian-kensaku dispatches to the picker currently selected by
+obsidian.nvim (`Obsidian.opts.picker.name`).
+
+| Picker | `:Obsidian kensaku <query>` (one-shot grep) | `:Obsidian kensaku` (live grep) | `:Obsidian quick_kensaku` (live filename) |
+| --- | --- | --- | --- |
+| telescope.nvim | ✓ | ✓ | ✓ |
+| fzf-lua | ✓ | planned (v3.4) | planned (v3.4) |
+| snacks.picker | ✓ | planned (v3.3) | planned (v3.3) |
+| mini.pick | ✓ | not planned | not planned |
+| default (`vim.ui.select`) | ✓ | n/a | n/a |
+
+For pickers other than telescope, the one-shot mode runs `rg` with the
+migemo-converted regex and feeds the matched results into the active
+picker via the host plugin's `obsidian.picker.pick()` API. This keeps the
+picker-specific code minimal.
+
+The live modes need picker-specific hooks (telescope's
+`on_input_filter_cb`, fzf-lua's `fzf_live`, snacks.picker's `finder`
+callback) and will land in follow-up releases.
 
 ## Install
 
@@ -66,23 +87,58 @@ This plugin uses [SemVer](https://semver.org/). The v3 line targets
 
 ### Add this plugin with your favorite plugin manager
 
+Recommended pattern is to list obsidian-kensaku.nvim as a dependency of
+obsidian.nvim and call `setup()` from obsidian.nvim's `post_setup` callback:
+
 ```lua
 -- example for lazy.nvim
 {
-  "delphinus/obsidian-kensaku.nvim",
-  version = "^3.1",
-  cmd = "Obsidian",
+  "obsidian-nvim/obsidian.nvim",
+  ft = "markdown",
+  cmd = { "Obsidian" },
   dependencies = {
-    "obsidian-nvim/obsidian.nvim",
-    { "delphinus/luamigemo", version = "*" },
+    {
+      "delphinus/obsidian-kensaku.nvim",
+      version = "^3.2",
+      dependencies = { { "delphinus/luamigemo", version = "*" } },
+    },
   },
-  opts = {},
+  opts = {
+    legacy_commands = false,
+    callbacks = {
+      post_setup = function()
+        require("obsidian-kensaku").setup {
+          -- picker = "egrepify",
+        }
+      end,
+    },
+    -- ... other obsidian.nvim opts ...
+  },
 }
 ```
 
-`cmd = "Obsidian"` makes lazy.nvim load both this plugin and obsidian.nvim on
-the first `:Obsidian ...` invocation, so the `:Obsidian kensaku` /
-`:Obsidian quick_kensaku` subcommands are registered before they are dispatched.
+Why this pattern instead of just `opts = {}` on the obsidian-kensaku.nvim spec?
+If both plugins claim the same lazy trigger (e.g., `cmd = "Obsidian"`),
+lazy.nvim's `handler.del` will delete the real `:Obsidian` user command
+after the last claiming plugin loads — even when it was just registered by
+obsidian.nvim's own `plugin/obsidian.lua`. Loading obsidian-kensaku.nvim as
+a dep avoids the trigger collision entirely.
+
+With this layout the legacy `:ObsidianKensaku` / `:ObsidianQuickKensaku`
+user commands only exist after the host plugin has been loaded for the
+first time (e.g., on the first markdown buffer or `:Obsidian ...`
+invocation). If you rely on the legacy forms before that, add them to a
+nested spec for obsidian-kensaku.nvim — they are kensaku-exclusive so
+they don't collide with `:Obsidian`:
+
+```lua
+{
+  "delphinus/obsidian-kensaku.nvim",
+  version = "^3.2",
+  cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+  dependencies = { { "delphinus/luamigemo", version = "*" } },
+},
+```
 
 `opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for you.
 For other plugin managers, call `setup` manually:
@@ -152,6 +208,7 @@ grep-based search. Overrides the built-in migemo engine.
 * type: `"default"|"egrepify"`
 
 Use [fdschmidt93/telescope-egrepify.nvim][] instead of telescope's builtin.
+Telescope only; ignored when obsidian.nvim is using a non-telescope picker.
 
 ### `previewer`
 
@@ -159,8 +216,11 @@ Use [fdschmidt93/telescope-egrepify.nvim][] instead of telescope's builtin.
 * type: `fun(): table`
 
 A function that returns a custom telescope previewer. When set, it is used
-for all picker commands. For example, [delphinus/md-render.nvim][] can render
-Markdown in the preview window:
+for all picker commands. Telescope only; ignored when obsidian.nvim is
+using a non-telescope picker.
+
+For example, [delphinus/md-render.nvim][] can render Markdown in the preview
+window:
 
 ```lua
 {

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -6,6 +6,7 @@
 はじめに					 |obsidian-kensaku-introduction|
 必要なもの					 |obsidian-kensaku-requirements|
 インストール					      |obsidian-kensaku-install|
+ピッカー対応状況			       |obsidian-kensaku-picker-support|
 コマンド					     |obsidian-kensaku-commands|
 オプション					      |obsidian-kensaku-options|
 ライセンス					      |obsidian-kensaku-license|
@@ -44,9 +45,17 @@ obsidian-kensaku.nvim は |obsidian.nvim| にローマ字検索機能を追加�
     https://github.com/obsidian-nvim/obsidian.nvim
 - delphinus/luamigemo (辞書内蔵 — 追加ダウンロード不要)
     https://github.com/delphinus/luamigemo
-- nvim-telescope/telescope.nvim
-    https://github.com/nvim-telescope/telescope.nvim
-- fdschmidt93/telescope-egrepify.nvim (任意、推奨)
+- obsidian.nvim がサポートするピッカーのいずれか:
+    nvim-telescope/telescope.nvim
+        https://github.com/nvim-telescope/telescope.nvim
+    ibhagwan/fzf-lua
+        https://github.com/ibhagwan/fzf-lua
+    folke/snacks.nvim (snacks.picker)
+        https://github.com/folke/snacks.nvim
+    echasnovski/mini.pick
+        https://github.com/echasnovski/mini.pick
+  機能対応の詳細は |obsidian-kensaku-picker-support| を参照。
+- fdschmidt93/telescope-egrepify.nvim (任意、telescope 利用時のみ)
     https://github.com/fdschmidt93/telescope-egrepify.nvim
 
 ==============================================================================
@@ -64,22 +73,50 @@ v2 系はアーカイブされた epwalsh/obsidian.nvim を対象とします。
     }
 <
 
-lazy.nvim 設定例: >lua
+推奨は obsidian-kensaku.nvim を obsidian.nvim の dependencies に並べ、
+obsidian.nvim の `post_setup` コールバックから `setup()` を呼ぶ形です: >lua
     {
-      "delphinus/obsidian-kensaku.nvim",
-      version = "^3.1",
-      cmd = "Obsidian",
+      "obsidian-nvim/obsidian.nvim",
+      ft = "markdown",
+      cmd = { "Obsidian" },
       dependencies = {
-        "obsidian-nvim/obsidian.nvim",
-        { "delphinus/luamigemo", version = "*" },
+        {
+          "delphinus/obsidian-kensaku.nvim",
+          version = "^3.2",
+          dependencies = { { "delphinus/luamigemo", version = "*" } },
+        },
       },
-      opts = {},
+      opts = {
+        legacy_commands = false,
+        callbacks = {
+          post_setup = function()
+            require("obsidian-kensaku").setup {
+              -- picker = "egrepify",
+            }
+          end,
+        },
+      },
     }
 <
-`cmd = "Obsidian"` を指定することで、 lazy.nvim は `:Obsidian ...` を
-初めて呼んだときに本プラグインと obsidian.nvim を両方ロードします。これに
-より `:Obsidian kensaku` / `:Obsidian quick_kensaku` サブコマンドが
-ディスパッチ前に登録された状態になります。
+
+両方のプラグインが同じ lazy.nvim トリガ (例: `cmd = "Obsidian"`) を
+claim していると、 lazy.nvim の `handler.del` が「最後にロードされたプラ
+グインの disable 時点」で `:Obsidian` ユーザコマンドを削除してしまいます。
+obsidian.nvim 本体の `plugin/obsidian.lua` が登録した real コマンドも巻き
+込まれて消えるので、 dep として読み込ませてトリガ衝突を避けます。
+
+この構成だと legacy 名の |:ObsidianKensaku| / |:ObsidianQuickKensaku| は
+host plugin が初めて読み込まれた後 (markdown バッファを開く、 `:Obsidian
+...` を呼ぶ等) でないと存在しません。 読み込み前から legacy 名で呼びたい
+場合は、 obsidian-kensaku.nvim 側に `cmd` を足してください。これらは
+kensaku 専用なので `:Obsidian` トリガと衝突しません: >lua
+    {
+      "delphinus/obsidian-kensaku.nvim",
+      version = "^3.2",
+      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+      dependencies = { { "delphinus/luamigemo", version = "*" } },
+    }
+<
 `opts = {}` を指定すると lazy.nvim が自動で
 `require("obsidian-kensaku").setup()` を呼び出します。他のプラグインマネージャ
 を使う場合は手動で `setup` を呼んでください: >lua
@@ -92,6 +129,26 @@ lazy.nvim 設定例: >lua
 手順は廃止され、`setup()` は単体で完結します。コマンド呼び出し時点までに
 obsidian.nvim が初期化されていれば動作するため、上記例のように
 `obsidian-nvim/obsidian.nvim` を `dependencies` に並べておけば十分です。
+
+==============================================================================
+ピッカー対応状況			       *obsidian-kensaku-picker-support*
+
+obsidian-kensaku は obsidian.nvim が現在使用しているピッカー
+(`Obsidian.opts.picker.name`) に dispatch します。
+
+	ピッカー	  one-shot grep   live grep      live filename
+	----------------  --------------  -------------  ----------------
+	telescope.nvim	  対応		  対応		 対応
+	fzf-lua		  対応		  v3.4 で対応予定 v3.4 で対応予定
+	snacks.picker	  対応		  v3.3 で対応予定 v3.3 で対応予定
+	mini.pick	  対応		  未予定	 未予定
+	default		  対応		  n/a		 n/a
+
+telescope 以外では、 one-shot モードは `rg` を migemo 変換後の正規表現で実行
+し、ホストプラグインの `obsidian.picker.pick()` API にマッチ結果を流し込み
+ます。 live モードはピッカーごとの専用フック (telescope の
+`on_input_filter_cb`、 fzf-lua の `fzf_live`、 snacks.picker の `finder`
+コールバック) が必要なため、 後続リリースで段階的に追加します。
 
 ==============================================================================
 コマンド					     *obsidian-kensaku-commands*
@@ -154,14 +211,19 @@ picker ~
 	使用する telescope ピッカー。 `"egrepify"` に設定すると
 	telescope-egrepify.nvim を使用し、正規表現のハイライトが改善されます。
 
+	telescope 使用時のみ有効。 obsidian.nvim が他ピッカーを使っている場合は
+	無視されます。
+
 						    *obsidian-kensaku-previewer*
 previewer ~
 	型: `fun(): table`
 	デフォルト: `nil`
 
 	カスタム telescope プレビューアを返す関数。設定すると、すべてのピッ
-	カーコマンドで使用されます。例えば md-render.nvim を使うとプレビューで
-	Markdown を描画できます。
+	カーコマンドで使用されます。telescope 使用時のみ有効。 obsidian.nvim
+	が他ピッカーを使っている場合は無視されます。
+
+	例えば md-render.nvim を使うとプレビューで Markdown を描画できます。
 
 	  https://github.com/delphinus/md-render.nvim
 

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -6,6 +6,7 @@ CONTENTS					     *obsidian-kensaku-contents*
 Introduction				         |obsidian-kensaku-introduction|
 Requirements				         |obsidian-kensaku-requirements|
 Installation				              |obsidian-kensaku-install|
+Picker support				       |obsidian-kensaku-picker-support|
 Commands				             |obsidian-kensaku-commands|
 Options					              |obsidian-kensaku-options|
 License					              |obsidian-kensaku-license|
@@ -44,9 +45,17 @@ REQUIREMENTS				         *obsidian-kensaku-requirements*
     https://github.com/obsidian-nvim/obsidian.nvim
 - delphinus/luamigemo (dictionary bundled — no extra download needed)
     https://github.com/delphinus/luamigemo
-- nvim-telescope/telescope.nvim
-    https://github.com/nvim-telescope/telescope.nvim
-- fdschmidt93/telescope-egrepify.nvim (optional, recommended)
+- One of the pickers supported by obsidian.nvim:
+    nvim-telescope/telescope.nvim
+        https://github.com/nvim-telescope/telescope.nvim
+    ibhagwan/fzf-lua
+        https://github.com/ibhagwan/fzf-lua
+    folke/snacks.nvim (snacks.picker)
+        https://github.com/folke/snacks.nvim
+    echasnovski/mini.pick
+        https://github.com/echasnovski/mini.pick
+  See |obsidian-kensaku-picker-support| for the feature matrix.
+- fdschmidt93/telescope-egrepify.nvim (optional, telescope only)
     https://github.com/fdschmidt93/telescope-egrepify.nvim
 
 ==============================================================================
@@ -63,22 +72,52 @@ v2 line targets the archived epwalsh/obsidian.nvim. Pin accordingly: >lua
     }
 <
 
-Example configuration with lazy.nvim: >lua
+Recommended pattern is to list obsidian-kensaku.nvim as a dependency of
+obsidian.nvim and call `setup()` from obsidian.nvim's `post_setup`
+callback: >lua
     {
-      "delphinus/obsidian-kensaku.nvim",
-      version = "^3.1",
-      cmd = "Obsidian",
+      "obsidian-nvim/obsidian.nvim",
+      ft = "markdown",
+      cmd = { "Obsidian" },
       dependencies = {
-        "obsidian-nvim/obsidian.nvim",
-        { "delphinus/luamigemo", version = "*" },
+        {
+          "delphinus/obsidian-kensaku.nvim",
+          version = "^3.2",
+          dependencies = { { "delphinus/luamigemo", version = "*" } },
+        },
       },
-      opts = {},
+      opts = {
+        legacy_commands = false,
+        callbacks = {
+          post_setup = function()
+            require("obsidian-kensaku").setup {
+              -- picker = "egrepify",
+            }
+          end,
+        },
+      },
     }
 <
-`cmd = "Obsidian"` makes lazy.nvim load both this plugin and obsidian.nvim
-on the first `:Obsidian ...` invocation, so the `:Obsidian kensaku` /
-`:Obsidian quick_kensaku` subcommands are registered before they are
-dispatched.
+
+If both plugins claim the same lazy.nvim trigger (e.g., `cmd = "Obsidian"`),
+lazy.nvim's `handler.del` will delete the real `:Obsidian` user command
+after the last claiming plugin loads — even when it was just registered by
+obsidian.nvim's own `plugin/obsidian.lua`. Loading obsidian-kensaku.nvim as
+a dep avoids the trigger collision entirely.
+
+With this layout the legacy |:ObsidianKensaku| / |:ObsidianQuickKensaku|
+user commands only exist after the host plugin has been loaded for the
+first time (e.g., on the first markdown buffer or `:Obsidian ...`
+invocation). If you rely on the legacy forms before that, add them as
+`cmd` triggers on a nested obsidian-kensaku.nvim spec — they are
+kensaku-exclusive so they don't collide with `:Obsidian`: >lua
+    {
+      "delphinus/obsidian-kensaku.nvim",
+      version = "^3.2",
+      cmd = { "ObsidianKensaku", "ObsidianQuickKensaku" },
+      dependencies = { { "delphinus/luamigemo", version = "*" } },
+    }
+<
 `opts = {}` makes lazy.nvim call `require("obsidian-kensaku").setup()` for
 you. For other plugin managers, call `setup` manually: >lua
     require("obsidian-kensaku").setup {
@@ -90,6 +129,27 @@ of obsidian.nvim. v3 drops that — `setup()` is self-contained, and
 obsidian.nvim only needs to have been initialized by the time you invoke a
 command. Listing `obsidian-nvim/obsidian.nvim` as a dependency (as above)
 handles that for you.
+
+==============================================================================
+PICKER SUPPORT				       *obsidian-kensaku-picker-support*
+
+obsidian-kensaku dispatches to the picker currently selected by
+obsidian.nvim (`Obsidian.opts.picker.name`).
+
+	Picker		  one-shot grep   live grep      live filename
+	----------------  --------------  -------------  ----------------
+	telescope.nvim	  yes		  yes		 yes
+	fzf-lua		  yes		  planned (3.4)  planned (3.4)
+	snacks.picker	  yes		  planned (3.3)  planned (3.3)
+	mini.pick	  yes		  not planned	 not planned
+	default		  yes		  n/a		 n/a
+
+For pickers other than telescope, the one-shot mode runs `rg` with the
+migemo-converted regex and feeds the matched results into the active
+picker via the host plugin's `obsidian.picker.pick()` API. The live modes
+need picker-specific hooks (telescope's `on_input_filter_cb`, fzf-lua's
+`fzf_live`, snacks.picker's `finder` callback) and will land in
+follow-up releases.
 
 ==============================================================================
 COMMANDS				             *obsidian-kensaku-commands*
@@ -154,14 +214,19 @@ picker ~
 	The telescope picker to use. Set to `"egrepify"` to use
 	telescope-egrepify.nvim, which provides better regex highlighting.
 
+	Telescope only; ignored when obsidian.nvim is using a non-telescope
+	picker.
+
 						    *obsidian-kensaku-previewer*
 previewer ~
 	Type: `fun(): table`
 	Default: `nil`
 
 	A function that returns a custom telescope previewer. When set, it is
-	used for all picker commands. For example, md-render.nvim can render
-	Markdown in the preview window.
+	used for all picker commands. Telescope only; ignored when
+	obsidian.nvim is using a non-telescope picker.
+
+	For example, md-render.nvim can render Markdown in the preview window.
 
 	  https://github.com/delphinus/md-render.nvim
 

--- a/lua/obsidian-kensaku/picker/_telescope.lua
+++ b/lua/obsidian-kensaku/picker/_telescope.lua
@@ -199,6 +199,7 @@ M.grep_notes = function(opts)
       previewer = previewer,
       vimgrep_arguments = search.build_grep_cmd { fixed_strings = false },
       search = config.query_filter(opts.query),
+      use_regex = true,
       attach_mappings = attach_mappings,
     }
   else

--- a/lua/obsidian-kensaku/picker/init.lua
+++ b/lua/obsidian-kensaku/picker/init.lua
@@ -1,0 +1,120 @@
+local Picker = require "obsidian.picker"
+local PickerName = require("obsidian.config").Picker
+local log = require "obsidian.log"
+local api = require "obsidian.api"
+
+local config = require "obsidian-kensaku.config"
+
+local M = {}
+
+---@return string|nil
+local function active_picker_name()
+  if Obsidian and Obsidian.opts and Obsidian.opts.picker and Obsidian.opts.picker.name then
+    return Obsidian.opts.picker.name
+  end
+  -- Match obsidian.nvim's auto-detection order in Obsidian.picker.get().
+  for _, info in ipairs {
+    { PickerName.telescope, "telescope.builtin" },
+    { PickerName.fzf_lua, "fzf-lua" },
+    { PickerName.snacks, "snacks.picker" },
+    { PickerName.mini, "mini.pick" },
+  } do
+    if pcall(require, info[2]) then
+      return info[1]
+    end
+  end
+  return nil
+end
+
+---Run rg with a regex pattern under the vault and return parsed picker entries.
+---Synchronous; intended for one-shot grep where the query is already known.
+---@param regex string
+---@param dir string|obsidian.Path
+---@return obsidian.PickerEntry[]
+local function rg_to_entries(regex, dir)
+  local cmd = {
+    "rg",
+    "--vimgrep",
+    "--no-heading",
+    "--smart-case",
+    "--color=never",
+    "--type=md",
+    "--",
+    regex,
+    tostring(dir),
+  }
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 and result.code ~= 1 then
+    log.err("obsidian-kensaku: rg exited with code %d: %s", result.code, result.stderr or "")
+    return {}
+  end
+
+  local entries = {}
+  for line in (result.stdout or ""):gmatch "[^\n]+" do
+    local fname, lnum, col, text = line:match "^(.-):(%d+):(%d+):(.*)$"
+    if fname then
+      entries[#entries + 1] = {
+        filename = fname,
+        lnum = tonumber(lnum),
+        col = tonumber(col),
+        text = text,
+        value = text,
+      }
+    end
+  end
+  return entries
+end
+
+---@param opts? table
+M.find_notes = function(opts)
+  local name = active_picker_name()
+  if name == PickerName.telescope then
+    require("obsidian-kensaku.picker._telescope").find_notes(opts)
+    return
+  end
+  log.err(
+    "obsidian-kensaku: filename search with migemo is currently telescope.nvim only "
+      .. "(active picker: %s). Support for fzf-lua / snacks.picker is planned.",
+    name or "default"
+  )
+end
+
+---@param opts? { query?: string, dir?: string|obsidian.Path, prompt_title?: string, callback?: fun(entry: table) }
+M.grep_notes = function(opts)
+  opts = opts or {}
+  local name = active_picker_name()
+
+  if name == PickerName.telescope then
+    require("obsidian-kensaku.picker._telescope").grep_notes(opts)
+    return
+  end
+
+  if not (opts.query and #opts.query > 0) then
+    log.err(
+      "obsidian-kensaku: live grep with migemo is currently telescope.nvim only "
+        .. "(active picker: %s). Pass an initial query (`:Obsidian kensaku <query>`) "
+        .. "to use the one-shot mode supported by all pickers.",
+      name or "default"
+    )
+    return
+  end
+
+  local dir = opts.dir or Obsidian.dir
+  local regex = config.query_filter(opts.query)
+  local entries = rg_to_entries(regex, dir)
+  if #entries == 0 then
+    log.info("obsidian-kensaku: no matches for `%s`.", opts.query)
+    return
+  end
+
+  Picker.pick(entries, {
+    prompt_title = opts.prompt_title or ("Grep notes (migemo): " .. opts.query),
+    callback = opts.callback or function(entry)
+      if entry then
+        api.open_note(entry)
+      end
+    end,
+  })
+end
+
+return M


### PR DESCRIPTION
## Summary

- Restructure the picker integration into a thin dispatcher (`lua/obsidian-kensaku/picker/init.lua`) that selects the backend based on `Obsidian.opts.picker.name`. The existing telescope implementation moves to `picker/_telescope.lua` unchanged.
- For non-telescope pickers, wire up the one-shot mode (`:Obsidian kensaku <query>`): run `rg` with the migemo-converted regex and feed the results into the host plugin's `obsidian.picker.pick()` API. This gives mini.pick / snacks.picker / fzf-lua / default users a working `:Obsidian kensaku <query>` without any picker-specific code.
- Live grep / live filename support for snacks.picker and fzf-lua is planned for follow-up releases. mini.pick and default stay one-shot-only.
- Fix a long-standing telescope one-shot bug: `grep_string` defaults to `use_regex = false`, which silently escaped the migemo regex into a literal string. Pass `use_regex = true` so the regex actually matches.
- Change the recommended lazy.nvim install pattern to load kensaku as an obsidian.nvim **dependency** and call `setup()` from obsidian.nvim's `post_setup` callback. The previous `opts = {}` / `cmd = "Obsidian"` pattern triggered a lazy.nvim `handler.del` race that deleted the host plugin's real `:Obsidian` user command after both plugins finished loading. Loading kensaku as a dep avoids the trigger collision entirely.

## Notes

- Public API unchanged: `require("obsidian-kensaku.picker").grep_notes(opts)` / `.find_notes(opts)` still work.
- Legacy `:ObsidianKensaku` / `:ObsidianQuickKensaku` user commands only exist after the host plugin has been loaded for the first time. README documents how to opt back into eager registration via a nested `cmd` trigger.

## Test plan

- [x] `:Obsidian kensaku <query>` with telescope — picker opens with migemo-matched results
- [x] `:Obsidian kensaku` (live) with telescope — picker streams migemo-matched results as you type
- [x] `:Obsidian quick_kensaku` with telescope — filename picker, migemo input matches Japanese filenames
- [x] Repeated nvim restarts: `:Obsidian kensaku ...` reliably finds the subcommand (no `Command 'Obsidian' not found` race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)