### PR TITLE
fix(telescope): pass FLAG_NFD when matching filenames

### DIFF
--- a/lua/obsidian-kensaku/picker/_telescope.lua
+++ b/lua/obsidian-kensaku/picker/_telescope.lua
@@ -139,7 +139,10 @@ M.find_notes = function(opts)
     on_input_filter_cb = function(prompt)
       local migemo = require "luamigemo"
       local m = migemo.get(config.dict_path)
-      local result = m:query(prompt, migemo.RXOP_VIM)
+      -- FLAG_NFD: filenames returned by macOS APFS / iCloud Drive arrive in
+      -- NFD form (e.g. ブ → フ + U+3099), so the regex must tolerate both
+      -- composed and decomposed kana.
+      local result = m:query(prompt, migemo.RXOP_VIM, migemo.FLAG_NFD)
       return { prompt = migemo.VIM_PREFIX .. result }
     end,
     attach_mappings = function(_, map)


### PR DESCRIPTION
## Summary

macOS APFS / iCloud Drive return Japanese filenames in NFD form (e.g. `ブ` is stored as `フ` + U+3099). The migemo regex built for the prompt was using NFC bytes, so files like `20260518-181647-b4fc-Inventory-サブモジュール更新の影響評価と確認完了.md` never matched a `sabu` search via `find_notes`.

luamigemo's new `FLAG_NFD` (3rd arg of `query`) makes the generated regex tolerate both NFC and NFD voiced kana. See https://github.com/delphinus/luamigemo/pull/1.

## Compatibility

Soft requirement on the new luamigemo. On older luamigemo `M.FLAG_NFD` is `nil` and the call silently degrades to the prior behavior (no error, but NFD filenames keep missing). Update luamigemo to recover NFD matching.

## Scope

Only `find_notes` (filename matching) gets `FLAG_NFD`. `grep_notes` matches against file contents, which are typically NFC for editor-written files; leaving it unchanged keeps the regex smaller for that path.

## Test plan

- [x] Verified against real macOS APFS NFD filename `20260518-181647-b4fc-Inventory-サブモジュール更新の影響評価と確認完了.md` — matches `sabu` after the fix
- [x] Manual telescope test (`<Leader>oq sabu`) in the user's vault: the target file now appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)