### PR TITLE
feat(snacks): live filename and grep modes for snacks.picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,19 +55,19 @@ obsidian.nvim (`Obsidian.opts.picker.name`).
 | Picker | `:Obsidian kensaku <query>` (one-shot grep) | `:Obsidian kensaku` (live grep) | `:Obsidian quick_kensaku` (live filename) |
 | --- | --- | --- | --- |
 | telescope.nvim | ✓ | ✓ | ✓ |
-| fzf-lua | ✓ | planned (v3.4) | planned (v3.4) |
-| snacks.picker | ✓ | planned (v3.3) | planned (v3.3) |
+| snacks.picker | ✓ | ✓ | ✓ |
+| fzf-lua | ✓ | planned (v3.5) | planned (v3.5) |
 | mini.pick | ✓ | not planned | not planned |
 | default (`vim.ui.select`) | ✓ | n/a | n/a |
 
-For pickers other than telescope, the one-shot mode runs `rg` with the
-migemo-converted regex and feeds the matched results into the active
-picker via the host plugin's `obsidian.picker.pick()` API. This keeps the
-picker-specific code minimal.
+For pickers other than telescope / snacks.picker, the one-shot mode runs
+`rg` with the migemo-converted regex and feeds the matched results into
+the active picker via the host plugin's `obsidian.picker.pick()` API.
+This keeps the picker-specific code minimal.
 
-The live modes need picker-specific hooks (telescope's
-`on_input_filter_cb`, fzf-lua's `fzf_live`, snacks.picker's `finder`
-callback) and will land in follow-up releases.
+The live modes need picker-specific hooks: telescope uses
+`on_input_filter_cb`, snacks.picker uses a custom `finder` callback. The
+fzf-lua live integration (`fzf_live`) is planned for v3.5.
 
 ## Install
 

--- a/doc/obsidian-kensaku.jax
+++ b/doc/obsidian-kensaku.jax
@@ -139,16 +139,18 @@ obsidian-kensaku は obsidian.nvim が現在使用しているピッカー
 	ピッカー	  one-shot grep   live grep      live filename
 	----------------  --------------  -------------  ----------------
 	telescope.nvim	  対応		  対応		 対応
-	fzf-lua		  対応		  v3.4 で対応予定 v3.4 で対応予定
-	snacks.picker	  対応		  v3.3 で対応予定 v3.3 で対応予定
+	snacks.picker	  対応		  対応		 対応
+	fzf-lua		  対応		  v3.5 で対応予定 v3.5 で対応予定
 	mini.pick	  対応		  未予定	 未予定
 	default		  対応		  n/a		 n/a
 
-telescope 以外では、 one-shot モードは `rg` を migemo 変換後の正規表現で実行
-し、ホストプラグインの `obsidian.picker.pick()` API にマッチ結果を流し込み
-ます。 live モードはピッカーごとの専用フック (telescope の
-`on_input_filter_cb`、 fzf-lua の `fzf_live`、 snacks.picker の `finder`
-コールバック) が必要なため、 後続リリースで段階的に追加します。
+telescope / snacks.picker 以外では、 one-shot モードは `rg` を migemo 変換後の
+正規表現で実行し、ホストプラグインの `obsidian.picker.pick()` API にマッチ
+結果を流し込みます。
+
+live モードはピッカーごとの専用フックが必要です: telescope は
+`on_input_filter_cb`、 snacks.picker は専用の `finder` コールバックを使い
+ます。 fzf-lua の live 対応 (`fzf_live`) は v3.5 で追加予定です。
 
 ==============================================================================
 コマンド					     *obsidian-kensaku-commands*

--- a/doc/obsidian-kensaku.txt
+++ b/doc/obsidian-kensaku.txt
@@ -139,17 +139,18 @@ obsidian.nvim (`Obsidian.opts.picker.name`).
 	Picker		  one-shot grep   live grep      live filename
 	----------------  --------------  -------------  ----------------
 	telescope.nvim	  yes		  yes		 yes
-	fzf-lua		  yes		  planned (3.4)  planned (3.4)
-	snacks.picker	  yes		  planned (3.3)  planned (3.3)
+	snacks.picker	  yes		  yes		 yes
+	fzf-lua		  yes		  planned (3.5)  planned (3.5)
 	mini.pick	  yes		  not planned	 not planned
 	default		  yes		  n/a		 n/a
 
-For pickers other than telescope, the one-shot mode runs `rg` with the
-migemo-converted regex and feeds the matched results into the active
-picker via the host plugin's `obsidian.picker.pick()` API. The live modes
-need picker-specific hooks (telescope's `on_input_filter_cb`, fzf-lua's
-`fzf_live`, snacks.picker's `finder` callback) and will land in
-follow-up releases.
+For pickers other than telescope / snacks.picker, the one-shot mode runs
+`rg` with the migemo-converted regex and feeds the matched results into
+the active picker via the host plugin's `obsidian.picker.pick()` API.
+
+The live modes need picker-specific hooks: telescope uses
+`on_input_filter_cb`, snacks.picker uses a custom `finder` callback. The
+fzf-lua live integration (`fzf_live`) is planned for v3.5.
 
 ==============================================================================
 COMMANDS				             *obsidian-kensaku-commands*

--- a/lua/obsidian-kensaku/picker/_snacks.lua
+++ b/lua/obsidian-kensaku/picker/_snacks.lua
@@ -1,0 +1,159 @@
+local Path = require "obsidian.path"
+
+local config = require "obsidian-kensaku.config"
+
+local M = {}
+
+---Build a PCRE regex string for the user's romaji input via migemo, with
+---FLAG_NFD so that NFD-decomposed filenames on macOS APFS / iCloud Drive
+---also match. Returns nil for an empty query.
+---@param query string
+---@return string|nil
+local function build_filename_pcre(query)
+  if not query or query == "" then
+    return nil
+  end
+  local migemo = require "luamigemo"
+  local m = migemo.get(config.dict_path)
+  local flags = migemo.FLAG_NFD or 0
+  return m:query(query, migemo.RXOP_PCRE, flags)
+end
+
+---@param opts? { dir?: string|obsidian.Path, prompt_title?: string, callback?: fun(path: string) }
+M.find_notes = function(opts)
+  opts = opts or {}
+  local cwd = opts.dir and tostring(opts.dir) or tostring(Obsidian.dir)
+
+  Snacks.picker.pick {
+    title = opts.prompt_title or "Notes (migemo)",
+    cwd = cwd,
+    live = true,
+    format = "file",
+    -- Filter `rg --files` through a second `rg` that matches the migemo
+    -- PCRE regex against each path. We do this in a subprocess instead of
+    -- in-process `vim.regex` for two reasons:
+    --
+    --   1. Safety. Calling `vim.regex:match_str()` from snacks's
+    --      check-handle coroutine re-enters `loop_poll_events` from
+    --      inside its own iteration and aborts the process. The outer
+    --      `picker:find()` runs in `vim.schedule` so the *outer* finder
+    --      could call `vim.regex` safely, but the inner async cb cannot.
+    --   2. Speed. Migemo expands short queries (e.g. "k") into ~10 KB
+    --      alternations with thousands of kanji. vim.regex's NFA/old
+    --      engines scan the full string on a miss, taking 1-5 s on a few
+    --      thousand files. rg's Aho-Corasick + DFA stays under 100 ms.
+    finder = function(_finder_opts, ctx)
+      local regex = build_filename_pcre(ctx.filter.search)
+      if not regex then
+        return function() end
+      end
+      return require("snacks.picker.source.proc").proc(
+        ctx:opts {
+          notify = false,
+          cmd = "sh",
+          args = {
+            "-c",
+            string.format(
+              "rg --files --type md %s | rg --regexp %s",
+              vim.fn.shellescape(cwd),
+              vim.fn.shellescape(regex)
+            ),
+          },
+          transform = function(item)
+            item.cwd = cwd
+            item.file = item.text
+            return item
+          end,
+        },
+        ctx
+      )
+    end,
+    confirm = function(picker, item)
+      picker:close()
+      if not item then
+        return
+      end
+      local path = item.file or item.text
+      if opts.callback then
+        opts.callback(path)
+      else
+        vim.cmd.edit(vim.fn.fnameescape(path))
+      end
+    end,
+  }
+end
+
+---Build rg vimgrep args for the given migemo PCRE regex.
+---@param regex string PCRE pattern
+---@param cwd string
+---@return string[]
+local function build_grep_args(regex, cwd)
+  return {
+    "--vimgrep",
+    "--no-heading",
+    "--smart-case",
+    "--color=never",
+    "--type=md",
+    "--",
+    regex,
+    cwd,
+  }
+end
+
+---@param opts? { dir?: string|obsidian.Path, prompt_title?: string, callback?: fun(entry: table) }
+M.grep_notes = function(opts)
+  opts = opts or {}
+  local cwd = opts.dir and Path.new(opts.dir) or Obsidian.dir
+  local cwd_str = tostring(cwd)
+
+  Snacks.picker.pick {
+    title = opts.prompt_title or "Grep notes (migemo)",
+    cwd = cwd_str,
+    live = true,
+    format = "file",
+    finder = function(_finder_opts, ctx)
+      local query = ctx.filter.search
+      if not query or query == "" then
+        return function() end
+      end
+      -- Use the project's query_filter so users can override the romaji
+      -- conversion. Default is migemo PCRE without VIM_PREFIX.
+      local regex = config.query_filter(query)
+      return require("snacks.picker.source.proc").proc(
+        ctx:opts {
+          notify = false,
+          cmd = "rg",
+          args = build_grep_args(regex, cwd_str),
+          transform = function(item)
+            local fname, lnum, col, text = item.text:match "^(.-):(%d+):(%d+):(.*)$"
+            if not fname then
+              return false
+            end
+            item.cwd = cwd_str
+            item.file = fname
+            item.pos = { tonumber(lnum), tonumber(col) - 1 }
+            item.text = text
+            return item
+          end,
+        },
+        ctx
+      )
+    end,
+    confirm = function(picker, item)
+      picker:close()
+      if not item then
+        return
+      end
+      if opts.callback then
+        opts.callback(item)
+      else
+        vim.cmd.edit(vim.fn.fnameescape(item.file))
+        if item.pos and item.pos[1] then
+          vim.api.nvim_win_set_cursor(0, { item.pos[1], item.pos[2] or 0 })
+        end
+      end
+    end,
+  }
+end
+
+return M

--- a/lua/obsidian-kensaku/picker/init.lua
+++ b/lua/obsidian-kensaku/picker/init.lua
@@ -72,9 +72,13 @@ M.find_notes = function(opts)
     require("obsidian-kensaku.picker._telescope").find_notes(opts)
     return
   end
+  if name == PickerName.snacks then
+    require("obsidian-kensaku.picker._snacks").find_notes(opts)
+    return
+  end
   log.err(
-    "obsidian-kensaku: filename search with migemo is currently telescope.nvim only "
-      .. "(active picker: %s). Support for fzf-lua / snacks.picker is planned.",
+    "obsidian-kensaku: filename search with migemo is currently telescope.nvim and "
+      .. "snacks.picker only (active picker: %s). Support for fzf-lua is planned.",
     name or "default"
   )
 end
@@ -89,11 +93,16 @@ M.grep_notes = function(opts)
     return
   end
 
+  if name == PickerName.snacks and not (opts.query and #opts.query > 0) then
+    require("obsidian-kensaku.picker._snacks").grep_notes(opts)
+    return
+  end
+
   if not (opts.query and #opts.query > 0) then
     log.err(
-      "obsidian-kensaku: live grep with migemo is currently telescope.nvim only "
-        .. "(active picker: %s). Pass an initial query (`:Obsidian kensaku <query>`) "
-        .. "to use the one-shot mode supported by all pickers.",
+      "obsidian-kensaku: live grep with migemo is currently telescope.nvim and "
+        .. "snacks.picker only (active picker: %s). Pass an initial query "
+        .. "(`:Obsidian kensaku <query>`) to use the one-shot mode supported by all pickers.",
       name or "default"
     )
     return


### PR DESCRIPTION
## Summary

- Add `lua/obsidian-kensaku/picker/_snacks.lua` implementing snacks.picker live filename search (`:Obsidian quick_kensaku`) and live grep (`:Obsidian kensaku`).
- Wire dispatch in `picker/init.lua`; update README and Vim helps so snacks.picker now shows ✓ across all three modes (one-shot grep / live grep / live filename).
- Bump fzf-lua live support target from v3.4 → v3.5 in the docs.

## Implementation notes

Both modes filter through `rg` via snacks's `proc` finder, not via in-process `vim.regex`:

1. **Safety**. The closure returned by our `finder` is invoked inside snacks's `uv.new_check()` callback — i.e. mid-`uv_run`. Calling `vim.regex:match_str()` there leads vim's NFA engine to invoke `os_breakcheck` → `loop_poll_events` → re-enter `uv_run`, which trips Neovim's nested-loop assertion and aborts the process (observed SIGABRT in `nfa_regmatch` on short queries like `k`).
2. **Speed**. The outer `finder` function does run in a `vim.schedule` context where `vim.regex` is safe, so we *could* return a table and match in-process. We benchmarked that path: vim.regex's NFA / old engines traverse the multi-KB migemo alternation in **1–5 seconds** for short queries against ~4500 files. rg's Aho-Corasick + DFA matcher does the same work in **under 100 ms** in a subprocess.

The grep mode (`grep_notes`) was already wired up similarly during earlier experimentation on this branch; `find_notes` now follows the same `sh -c "rg --files ... | rg --regexp <pcre>"` shape.

The telescope adapter has the same vim.regex performance characteristic but is left untouched for this release — tracking refactor as follow-up.

## Test plan

- [x] `<Leader>oq` (`:Obsidian quick_kensaku`) with short queries (`k`, `s`, `o`) — no SIGABRT, results in <200 ms
- [x] `<Leader>os` (`:Obsidian kensaku`) live grep with romaji input — matches Japanese content
- [x] `<Leader>oS` (`:Obsidian kensaku sabu`) one-shot grep — unchanged behavior
- [x] `:checkhealth obsidian` still passes (rg dependency was already required upstream)
- [ ] Verify on a vault without the previous luamigemo dictionary present

🤖 Generated with [Claude Code](https://claude.com/claude-code)