### PR TITLE
fix(telescope): follow build_find_cmd move in obsidian.nvim

### DIFF
--- a/lua/obsidian-kensaku/picker/_telescope.lua
+++ b/lua/obsidian-kensaku/picker/_telescope.lua
@@ -12,6 +12,21 @@ local config = require "obsidian-kensaku.config"
 
 local M = {}
 
+--- Build the `rg --files` command used as telescope's `find_command`.
+---
+--- obsidian.nvim#916 dropped the `obsidian.search.build_find_cmd` re-export
+--- (ripgrep became optional for finding files) and changed the backend
+--- signature from `(path, term, opts)` to `(path, opts)`. Dispatch on the
+--- re-export so both the old and the new layout work.
+---@return string[]
+local function build_find_cmd()
+  local opts = { include_non_markdown = false }
+  if search.build_find_cmd then
+    return search.build_find_cmd(nil, nil, opts)
+  end
+  return require("obsidian.search.ripgrep").build_find_cmd(nil, opts)
+end
+
 ---@param prompt_bufnr integer
 ---@param keep_open boolean|?
 ---@return table|?
@@ -134,7 +149,7 @@ M.find_notes = function(opts)
     prompt_title = opts.prompt_title or "Notes",
     cwd = opts.dir and tostring(opts.dir) or tostring(Obsidian.dir),
     previewer = config.previewer and config.previewer() or nil,
-    find_command = search.build_find_cmd(nil, nil, { include_non_markdown = false }),
+    find_command = build_find_cmd(),
     sorter = require "obsidian-kensaku.regex_sorter",
     on_input_filter_cb = function(prompt)
       local migemo = require "luamigemo"


### PR DESCRIPTION
## Summary

`:Obsidian quick_kensaku` (`find_notes` on telescope) crashes on current obsidian.nvim:

```
...picker/_telescope.lua:137: attempt to call field 'build_find_cmd' (a nil value)
```

obsidian-nvim/obsidian.nvim#916 (`refactor: fallback file walker and making rg optional in finding files`) made ripgrep optional for finding files. It dropped the `obsidian.search.build_find_cmd` re-export — only `build_grep_cmd` is still re-exported — and changed the backend signature from `(path, term, opts)` to `(path, opts)`.

This adds a local `build_find_cmd()` helper that dispatches on the re-export and falls back to `obsidian.search.ripgrep.build_find_cmd(path, opts)`.

## Compatibility

Both layouts keep working. The removal of the re-export and the signature change landed in the same commit, so the presence of `search.build_find_cmd` is a reliable discriminator:

- obsidian.nvim before #916: `search.build_find_cmd(nil, nil, opts)` as before.
- obsidian.nvim after #916: `obsidian.search.ripgrep.build_find_cmd(nil, opts)`.

`grep_notes` is unaffected — `search.build_grep_cmd` is still exported with the same signature.

## Test plan

- [x] Headless check against obsidian.nvim `07f94ef` (post-#916): the fallback branch returns `rg --no-config --type-add md:*.qmd --type-add md:*.base --files --ignore-case --type=md`, i.e. the same command the old path produced
- [x] `stylua --check`
- [ ] Manual `<Leader>oq` (`:Obsidian quick_kensaku`) in a real vault after release

🤖 Generated with [Claude Code](https://claude.com/claude-code)